### PR TITLE
add the input's max length as argument into QminderBridge.showKeyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Qminder API",
   "homepage": "http://www.qminderapp.com",
   "license": "Apache-2.0",

--- a/src/qminder-bridge.js
+++ b/src/qminder-bridge.js
@@ -42,8 +42,11 @@ var QminderBridge = (function() {
     keyboardSubmitListeners.push(callback);
   };
   
-  exports.showKeyboard = function(type) {
-    window.location = "qminder-signin://showKeyboardWithType/" + type;
+  exports.showKeyboard = function(type, maxLength) {
+    if (maxLength === undefined) {
+      maxLength = 50;
+    }
+    window.location = "qminder-signin://showKeyboardWithType/" + type + "/" + maxLength;
   };
   
   exports.hideKeyboard = function() {
@@ -98,4 +101,3 @@ var QminderBridge = (function() {
   
   return exports;
 }());
-


### PR DESCRIPTION
This PR allows QminderBridge.showKeyboard to set the maximum input length that the iOS application requires. It's passed as an integer inside the URL, and the code doesn't yet assert the parameter is valid. It however defaults to 50 when nothing is provided.

This fixes #37 
