### PR TITLE
Auto-increase socket retry timeout every 10 tries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Qminder API",
   "homepage": "http://www.qminderapp.com",
   "license": "Apache-2.0",

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -632,7 +632,7 @@ var Qminder = (function() {
         }
         
         var timeoutMult = Math.floor(socketRetriedConnections / 10);
-        setTimeout(openSocket, Math.min(5000 + timeoutMult * 1000, 15000));
+        setTimeout(openSocket, Math.min(5000 + timeoutMult * 1000, 60000));
         socketRetriedConnections++;
 
         if (onDisconnectedCallback !== null) {

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -565,6 +565,8 @@ var Qminder = (function() {
     var onConnectedCallback = null;
     var onDisconnectedCallback = null;
     
+    var socketRetriedConnections = 0;
+    
     var createId = function() {
       var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
       var text = "";
@@ -600,7 +602,7 @@ var Qminder = (function() {
       socket.onopen = function() {
         console.log("Connection opened");
         connectionOpen = true;
-        
+        socketRetriedConnections = 0;
         messageHistory.forEach(function(message) {
           sendMessage(message);
         });
@@ -629,9 +631,10 @@ var Qminder = (function() {
           pingInterval = null;
         }
         
-        console.log("Connection closed, Trying to reconnect in 5 seconds");
-        setTimeout(openSocket, 5000);
-        
+        var timeoutMult = Math.floor(socketRetriedConnections / 10);
+        setTimeout(openSocket, Math.min(5000 + timeoutMult * 1000, 15000));
+        socketRetriedConnections++;
+
         if (onDisconnectedCallback !== null) {
           onDisconnectedCallback();
         }

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -632,7 +632,9 @@ var Qminder = (function() {
         }
         
         var timeoutMult = Math.floor(socketRetriedConnections / 10);
-        setTimeout(openSocket, Math.min(5000 + timeoutMult * 1000, 60000));
+        var newTimeout = Math.min(5000 + timeoutMult * 1000, 60000);
+        console.log("Connection closed, Trying to reconnect in " + newTimeout/1000 + " seconds");
+        setTimeout(openSocket, newTimeout);
         socketRetriedConnections++;
 
         if (onDisconnectedCallback !== null) {


### PR DESCRIPTION
This PR increases the amount of time the code waits before trying to reconnect to the websocket. Starting from 5 seconds, the new behaviour increments the wait time by a second every 10 retries up to a maximum of 60 seconds. If a successful connection is made, the wait time is reset.