### PR TITLE
Re-connection triggering + Bridge update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Qminder API",
   "homepage": "http://www.qminderapp.com",
   "license": "Apache-2.0",

--- a/src/qminder-bridge.js
+++ b/src/qminder-bridge.js
@@ -7,6 +7,7 @@ var QminderBridge = (function() {
   var onLoadCallback = null;
   var inputFieldListeners = [];
   var keyboardSubmitListeners = [];
+  var activeChangeListeners = [];
 
   var receiveMessage = function(event) {
     if (event.data.secretKey) {
@@ -21,6 +22,10 @@ var QminderBridge = (function() {
     }
     else if (event.data.keyboardSubmitted) {
       keyboardSubmitListeners.forEach(function(listener) {
+        listener();
+      });
+    } else if (event.data.activeStatus) {
+      activeChangeListeners.forEach(function(listener) {
         listener();
       });
     }
@@ -40,6 +45,10 @@ var QminderBridge = (function() {
   
   exports.onKeyboardSubmit = function(callback) {
     keyboardSubmitListeners.push(callback);
+  };
+  
+  exports.onActiveChange = function(callback) {
+    activeChangeListeners.push(callback);
   };
   
   exports.showKeyboard = function(type, maxLength) {


### PR DESCRIPTION
This PR exposes two features:

(1) New API method to trigger a re-connection to the Qminder API events server. This method will automatically check if there is currently no connection, and if there isn't a pending connection.

(2) New Qminder Bridge method to pass events from the iOS app regarding the app's "active state" - whether the app is focused or not. 