### PR TITLE
Error callbacks receive original request and error event objects now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Qminder API",
   "homepage": "http://www.qminderapp.com",
   "license": "Apache-2.0",

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -84,12 +84,17 @@ var Qminder = (function() {
 
     request.onload = function() {
       var responseText = request.responseText;
-      var response = JSON.parse(responseText);
-      if (callback) {
-        callback(response);
-      }
-      else {
-        console.log("No callback function specified");
+      try {
+        var response = JSON.parse(responseText);
+        
+        if (callback) {
+          callback(response);
+        }
+        else {
+          console.log("No callback function specified");
+        }
+      } catch (error) {
+        errorCallback("JSON parse error", request, error);
       }
     };
 

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -96,18 +96,19 @@ var Qminder = (function() {
 
     request.onerror = function(error) {
       if (typeof errorCallback != "undefined") {
+        var errorMessage = "Something went wrong";
         
         if (request.status === 0) {
-          error = "Network error";
+          errorMessage = "Network error";
         }
         
-        errorCallback(error);
+        errorCallback(errorMessage, request, error);
       }
     };
     
     if (typeof errorCallback != "undefined") {
-      request.ontimeout = function() {
-        errorCallback("timeout");
+      request.ontimeout = function(error) {
+        errorCallback("timeout", request, error);
       };
     }
 

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -94,7 +94,9 @@ var Qminder = (function() {
           console.log("No callback function specified");
         }
       } catch (error) {
-        errorCallback("JSON parse error", request, error);
+        if (errorCallback) {
+          errorCallback("JSON parse error", request, error);
+        }
       }
     };
 


### PR DESCRIPTION
As well as that, error callbacks are now properly called out when `JSON.parse` throws an error.

Fixes #59 