### PR TITLE
Pass the user ID into the HTTP request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Qminder API",
   "homepage": "http://www.qminderapp.com",
   "license": "Apache-2.0",

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -330,6 +330,10 @@ var Qminder = (function() {
       
       var validParameters = ["line", "user", "phoneNumber", "firstName", "lastName", "extra"];
     
+      if (user) {
+        data += "user=" + user;
+      }
+    
       for (var key in parameters) {
         if (!parameters.hasOwnProperty(key)) {
           continue;


### PR DESCRIPTION
Fixes #61. Previously the "user" parameter was ignored, but now it isn't.