### PR TITLE
Make sure that JSON error handling will not catch callback errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Qminder API",
   "homepage": "http://www.qminderapp.com",
   "license": "Apache-2.0",

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -86,17 +86,18 @@ var Qminder = (function() {
       var responseText = request.responseText;
       try {
         var response = JSON.parse(responseText);
-        
-        if (callback) {
-          callback(response);
-        }
-        else {
-          console.log("No callback function specified");
-        }
       } catch (error) {
         if (errorCallback) {
-          errorCallback("JSON parse error", request, error);
+          errorCallback(error.message, request, error);
         }
+        return;
+      }
+
+      if (callback) {
+        callback(response);
+      }
+      else {
+        console.log("No callback function specified");
       }
     };
 

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -84,8 +84,9 @@ var Qminder = (function() {
 
     request.onload = function() {
       var responseText = request.responseText;
+      var response;
       try {
-        var response = JSON.parse(responseText);
+        response = JSON.parse(responseText);
       } catch (error) {
         if (errorCallback) {
           errorCallback(error.message, request, error);


### PR DESCRIPTION
This PR changes the behaviour of request(). It no longer calls the success callback inside a try-catch block, meaning that errors raised by the success callback will not propagate upward as errors of the surrounding API call.

Fixes #87 
