### PR TITLE
Don't assume a browser environment for WebSocket events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Qminder API",
   "homepage": "http://www.qminderapp.com",
   "license": "Apache-2.0",

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -717,7 +717,13 @@ var Qminder = (function() {
       }
       
       // Samsung Smart-TVs (2013) crashes with SSL
-      var supportsSSL = navigator.userAgent.match(/SMART-TV/i) === null;
+      // Non-browser environments are assumed to support SSL
+      var supportsSSL;
+      if (window && window.navigator) {
+        supportsSSL = navigator.userAgent.match(/SMART-TV/i) === null;
+      } else {
+        supportsSSL = true;
+      }
       
       var protocol = sslEnabled && supportsSSL ? "wss" : "ws";
       socket = new WebSocket(protocol + "://" + SERVER + "/events?rest-api-key=" + apiKey);


### PR DESCRIPTION
The API script will now check that a browser environment exists before doing user-agent matching to support the Samsung TV.

Fixes #97 
