### PR TITLE
Add CommonJS export to Qminder Bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Qminder API",
   "homepage": "https://www.qminder.com",
   "license": "Apache-2.0",

--- a/src/qminder-bridge.js
+++ b/src/qminder-bridge.js
@@ -110,3 +110,12 @@ var QminderBridge = (function() {
   
   return exports;
 }());
+
+// Nodejs support
+if (typeof module !== "undefined") {
+  module.exports = exports = QminderBridge;
+}
+
+if (typeof window !== "undefined") {
+  window.QminderBridge = QminderBridge;
+}


### PR DESCRIPTION
Fixes #113

This is useful for module loader support and lets us move to more modular ways of writing JS code.