### PR TITLE
Build a second web distribution: unbundled & ES6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build-node
 build-web
 node_modules
 docs
+build-es6

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "watch-tests": "./test/run-tests.sh --no-single-run",
     "build": "sh ./scripts/build-full.sh",
     "build-web": "./node_modules/.bin/webpack",
+    "build-web-unbundled": "sh ./scripts/build-web-unbundled.sh",
     "build-node": "sh ./scripts/build-node.sh",
     "watch": "npm run watch-web",
     "watch-web": "./node_modules/.bin/webpack --watch",
@@ -34,8 +35,8 @@
   "main": "build-node/qminder-api.js",
   "unpkg": "build-web/qminder-api.min.js",
   "module": "build-node/qminder-api.js",
-  "jsnext:main": "src/qminder-api.js",
-  "browser": "build-web/qminder-api.js",
+  "jsnext:main": "build-es6/qminder-api.js",
+  "browser": "build-es6/qminder-api.js",
   "repository": "Qminder/javascript-api",
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/scripts/build-full.sh
+++ b/scripts/build-full.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 set -e
-printf "\x1b[32mCompiling web...\x1b[0m\n"
+printf "\x1b[32mCompiling web bundled...\x1b[0m\n"
 npm run build-web
 
-printf "\x1b[32mTesting web...\x1b[0m\n"
+printf "\x1b[32mTesting web bundle...\x1b[0m\n"
 npm run test-web
+
+printf "\x1b[32mBuilding web unbundled...\x1b[0m\n"
+npm run build-web-unbundled
 
 printf "\x1b[32mCompiling node...\x1b[0m\n"
 npm run build-node
+

--- a/scripts/build-web-unbundled.sh
+++ b/scripts/build-web-unbundled.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+#
+# Compile Qminder API v2 for ES6 inclusion with tools like Closure Compiler.
+#
+
+# Use babel to compile all source files
+babel src \
+    -d build-es6 \
+    --quiet \
+    --plugins transform-flow-strip-types \
+    --presets es2017 \
+    --no-babelrc \
+    --no-comments
+
+# Use sed to replace VERSION in qminder-api.js
+qminderVersion=$(cat package.json | jq -r '.version')
+
+sedi () {
+    sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
+}
+
+sedi "s/VERSION/'$qminderVersion'/" build-es6/qminder-api.js
+
+# Use sed to replace ENV in fetch/websocket imports
+sedi "s:./lib/fetch-ENV:./lib/fetch-web:" build-es6/api-base.js
+sedi "s:../lib/websocket-ENV:../lib/websocket-web:" build-es6/services/EventsService.js
+
+# Copy all sources next to the compiled files, with ".flow" in the end of the name
+for flowSource in $(find src -name "*.js"); do
+    cutFlowSource=$(echo $flowSource | cut -c 5-)
+    echo ${flowSource} "->" ${cutFlowSource}.flow
+    cp ${flowSource} build-es6/${cutFlowSource}.flow
+done


### PR DESCRIPTION
This is for inclusion with jsnext:main-supporting module compilers such as Closure, which don't support UMD module definitions, but support ES6 modules.