### PR TITLE
Do not ignore node_modules in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
 "presets": ["es2017"],
-"ignore": "node_modules",
 "plugins": [
   "transform-flow-strip-types",
   "transform-async-to-generator",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"


### PR DESCRIPTION
This allows API consumers to build Qminder API from ES6+Flow source to JS themselves, utilizing tree-shaking and other benefits.