### PR TITLE
Setup Node.js testing & File API bugfix

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -1,0 +1,12 @@
+{
+  "spec_dir": "test/web",
+  "spec_files": [
+    "**/EventsService.test.js",
+    "**/*test.node.js"
+  ],
+  "helpers": [
+    "../node_helper.js"
+  ],
+  "stopSpecOnExpectationFailure": true,
+  "random": false
+}

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,7 +1,7 @@
 {
   "spec_dir": "test/web",
   "spec_files": [
-    "**/EventsService.test.js",
+    "**/*.test.js",
     "**/*test.node.js"
   ],
   "helpers": [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,8 +11,6 @@ module.exports = function(config) {
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ["jasmine", "sinon"],
 
-
-
     plugins: [
       'karma-chrome-launcher',
       'karma-jasmine',
@@ -24,6 +22,7 @@ module.exports = function(config) {
     files: [
       "build-web/qminder-api.js",
       "test/web/*.test.js",
+      "test/web/*.test.web.js"
     ],
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepare": "npm run build",
     "test": "npm run test-web",
     "test-web": "./test/run-tests.sh",
+    "test-node": "./test/run-node-tests.sh",
     "watch-tests": "./test/run-tests.sh --no-single-run",
     "build": "sh ./scripts/build-full.sh",
     "build-web": "./node_modules/.bin/webpack",

--- a/scripts/build-full.sh
+++ b/scripts/build-full.sh
@@ -12,3 +12,7 @@ npm run build-web-unbundled
 printf "\x1b[32mCompiling node...\x1b[0m\n"
 npm run build-node
 
+printf "\x1b[32mTesting node bundle...\x1b[0m\n"
+npm run test-node
+
+

--- a/src/api-base.js
+++ b/src/api-base.js
@@ -77,7 +77,7 @@ class ApiBase {
 
     if (data) {
       init.method = 'POST';
-      if (data instanceof File && init.headers) {
+      if (typeof File !== "undefined" && data instanceof File && init.headers) {
         init.body = data;
         // $FlowFixMe: there's an issue with the fetch RequestOptions type.
         init.headers['Content-Type'] = data.type;

--- a/test/mock-websocket-server.js
+++ b/test/mock-websocket-server.js
@@ -24,6 +24,19 @@ class MockWebsocketServer {
       controlHandler.setSocket(sock);
       connHandler.setControlSocket(sock);
     });
+
+    connHandler.onClose(() => {
+      console.log('\x1b[33m   main |\x1b[0m Connection closed - closing control');
+      if (controlHandler.connection.readyState === 1) {
+        controlHandler.connection.close();
+      }
+    });
+    controlHandler.onClose(() => {
+      console.log('\x1b[33m   main |\x1b[0m Control closed - closing connection');
+      if (connHandler.connection.readyState === 1) {
+        connHandler.connection.close();
+      }
+    });
   }
 }
 

--- a/test/node_helper.js
+++ b/test/node_helper.js
@@ -1,0 +1,8 @@
+// Loads Qminder API and Sinon for Node.js tests into this.Qminder and this.sinon.
+// The web tests automatically load the API and Sinon with Karma's file list & plugin system, so
+// they are available globally.
+beforeAll(function() {
+  this.Qminder = require('../build-node/qminder-api');
+  this.sinon = require('sinon');
+  this.isNode = true;
+});

--- a/test/run-node-tests.sh
+++ b/test/run-node-tests.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-set +e
+set -e
 # Start the mock WS server
 node ./test/mock-websocket-server.js >/dev/null &
 wspid=$!
 
 JASMINE_CONFIG_PATH=./jasmine.json ./node_modules/.bin/jasmine
 
-kill $wspid
+kill $wspid || :

--- a/test/run-node-tests.sh
+++ b/test/run-node-tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set +e
+# Start the mock WS server
+node ./test/mock-websocket-server.js >/dev/null &
+wspid=$!
+
+JASMINE_CONFIG_PATH=./jasmine.json ./node_modules/.bin/jasmine
+
+kill $wspid

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +e
+set -e
 # Start the mock WS server
 node ./test/mock-websocket-server.js >/dev/null &
 wspid=$!
@@ -9,4 +9,4 @@ wspid=$!
 echo "Suppressing logs. Allow logs in the karma config with captureConsole: true."
 ./node_modules/.bin/karma start --log-level error ${@:1}
 
-kill $wspid
+kill $wspid || :

--- a/test/web/ApiBase.test.js
+++ b/test/web/ApiBase.test.js
@@ -1,7 +1,12 @@
 describe("ApiBase", function () {
   const API_KEY = 'testing';
-
   beforeEach(function() {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
     // Manual reset for ApiBase - Karma doesn't reload the environment between tests.
     Qminder.ApiBase.initialized = false;
     Qminder.ApiBase.apiKey = undefined;

--- a/test/web/Configuration.test.js
+++ b/test/web/Configuration.test.js
@@ -1,5 +1,4 @@
 describe('Configuration', function() {
-  let isNode = false;
   describe('Qminder.setKey', function() {
     beforeEach(function() {
       if (typeof Qminder === 'undefined') {
@@ -11,9 +10,8 @@ describe('Configuration', function() {
       if (typeof window !== 'undefined') {
         this.webSocketStub = sinon.stub(window, 'WebSocket');
       } else {
-        this.webSocketStub = sinon.spy();
+        this.webSocketStub = sinon.spy(this, 'WebSocket');
       }
-      isNode = this.isNode;
       Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
       this.requestStub = sinon.stub(Qminder.ApiBase, 'request');
       this.requestStub.onFirstCall().resolves({ data: [] });
@@ -35,18 +33,13 @@ describe('Configuration', function() {
       expect(() => Qminder.events.onTicketCreated(() => {})).not.toThrow();
     });
 
-    // TODO: Test WebSockets on Node
-    if (!isNode) {
-      xit('uses the API key in the websocket handshake', function() {
-        Qminder.events.openSocket();
-        expect(this.webSocketStub.calledWith('wss://' + Qminder.events.apiServer + '/events?rest-api-key=F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn')).toBeTruthy();
-      });
-    }
+    xit('uses the API key in the websocket handshake', function() {
+      Qminder.events.openSocket();
+      expect(this.webSocketStub.calledWith('wss://' + Qminder.events.apiServer + '/events?rest-api-key=F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn')).toBeTruthy();
+    });
 
     afterEach(function() {
-      if (!this.isNode) {
-        this.webSocketStub.restore();
-      }
+      this.webSocketStub.restore();
       Qminder.ApiBase.request.restore();
     });
   });

--- a/test/web/Configuration.test.js
+++ b/test/web/Configuration.test.js
@@ -7,11 +7,7 @@ describe('Configuration', function() {
       if (typeof sinon === 'undefined') {
         sinon = this.sinon;
       }
-      if (typeof window !== 'undefined') {
-        this.webSocketStub = sinon.stub(window, 'WebSocket');
-      } else {
-        this.webSocketStub = sinon.spy(this, 'WebSocket');
-      }
+
       Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
       this.requestStub = sinon.stub(Qminder.ApiBase, 'request');
       this.requestStub.onFirstCall().resolves({ data: [] });
@@ -39,7 +35,6 @@ describe('Configuration', function() {
     });
 
     afterEach(function() {
-      this.webSocketStub.restore();
       Qminder.ApiBase.request.restore();
     });
   });

--- a/test/web/Configuration.test.js
+++ b/test/web/Configuration.test.js
@@ -1,7 +1,19 @@
 describe('Configuration', function() {
+  let isNode = false;
   describe('Qminder.setKey', function() {
     beforeEach(function() {
-      this.webSocketStub = sinon.stub(window, 'WebSocket');
+      if (typeof Qminder === 'undefined') {
+        Qminder = this.Qminder;
+      }
+      if (typeof sinon === 'undefined') {
+        sinon = this.sinon;
+      }
+      if (typeof window !== 'undefined') {
+        this.webSocketStub = sinon.stub(window, 'WebSocket');
+      } else {
+        this.webSocketStub = sinon.spy();
+      }
+      isNode = this.isNode;
       Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
       this.requestStub = sinon.stub(Qminder.ApiBase, 'request');
       this.requestStub.onFirstCall().resolves({ data: [] });
@@ -23,13 +35,18 @@ describe('Configuration', function() {
       expect(() => Qminder.events.onTicketCreated(() => {})).not.toThrow();
     });
 
-    xit('uses the API key in the websocket handshake', function() {
-      Qminder.events.openSocket();
-      expect(this.webSocketStub.calledWith('wss://' + Qminder.events.apiServer + '/events?rest-api-key=F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn')).toBeTruthy();
-    });
+    // TODO: Test WebSockets on Node
+    if (!isNode) {
+      xit('uses the API key in the websocket handshake', function() {
+        Qminder.events.openSocket();
+        expect(this.webSocketStub.calledWith('wss://' + Qminder.events.apiServer + '/events?rest-api-key=F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn')).toBeTruthy();
+      });
+    }
 
     afterEach(function() {
-      this.webSocketStub.restore();
+      if (!this.isNode) {
+        this.webSocketStub.restore();
+      }
       Qminder.ApiBase.request.restore();
     });
   });

--- a/test/web/DeviceService.test.js
+++ b/test/web/DeviceService.test.js
@@ -28,6 +28,12 @@ describe("Qminder.devices", function() {
   };
 
   beforeEach(function() {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
     Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
     Qminder.setServer('local.api.qminderapp.com');
     this.requestStub = sinon.stub(Qminder.ApiBase, 'request');

--- a/test/web/LineService.test.js
+++ b/test/web/LineService.test.js
@@ -10,6 +10,12 @@ describe("LineService", function() {
   const LOCATION_ID = 673;
 
   beforeEach(function() {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
     Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
     Qminder.setServer('local.api.qminderapp.com');
 

--- a/test/web/LocationService.test.js
+++ b/test/web/LocationService.test.js
@@ -43,6 +43,12 @@ describe("Qminder.locations", function() {
   const DESKS = [1, 2, 3, 4].map(x => ({ name: `${x}` }));
 
   beforeEach(function() {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
     Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
     Qminder.setServer('local.api.qminderapp.com');
     this.requestStub = sinon.stub(Qminder.ApiBase, 'request');

--- a/test/web/TicketService.test.js
+++ b/test/web/TicketService.test.js
@@ -1,5 +1,11 @@
 describe("TicketService", function() {
   beforeEach(function() {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
     Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
     Qminder.setServer('local.api.qminderapp.com');
     this.requestStub = sinon.stub(Qminder.ApiBase, 'request');

--- a/test/web/UserService.test.js
+++ b/test/web/UserService.test.js
@@ -30,6 +30,12 @@ describe("UserService", function() {
   const pictureSort = (a, b) => pictureSizes[a.size] - pictureSizes[b.size];
 
   beforeEach(function() {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
     Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
     Qminder.setServer('local.api.qminderapp.com');
 

--- a/test/web/WebhooksService.test.js
+++ b/test/web/WebhooksService.test.js
@@ -1,5 +1,11 @@
 describe('Qminder.webhooks', function() {
   beforeEach(function() {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
     Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
     Qminder.setServer('local.api.qminderapp.com');
     this.requestStub = sinon.stub(Qminder.ApiBase, 'request');


### PR DESCRIPTION
This PR fixes #156 - ApiBase.js tried to use File in determining the type of payload to send in POST requests.

Additionally, this PR sets up tests for Node.js - bringing with it a few changes to the test code, such as not entirely depending on global variables (Jasmine.js does not support that). 

Lastly, the PR improves stability of mock-websocket-server by waiting for both control & client sockets to be open before event tests, and by having the server clean up both ends of the socket if one drops.