### PR TITLE
TicketService#reorder - reorder-first payload fix + Ticket object handling fix

### DIFF
--- a/src/services/TicketService.js
+++ b/src/services/TicketService.js
@@ -962,10 +962,25 @@ export default class TicketService {
       ticketId = ticket;
     }
 
+    let afterTicketId: ?number = null;
+    if (afterTicket instanceof Ticket) {
+      afterTicketId = afterTicket.id;
+    } else {
+      afterTicketId = afterTicket;
+    }
+
+    let postData: { after: number } = undefined;
+    if (afterTicketId) {
+      console.log('afterTicketId is truthy', { afterTicketId });
+      postData = {
+        after: afterTicketId,
+      };
+    }
+
     if (!ticketId || typeof ticketId !== 'number') {
       throw new Error(ERROR_NO_TICKET_ID);
     }
-    return ApiBase.request(`tickets/${ticketId}/reorder`, { after: afterTicket || null })
+    return ApiBase.request(`tickets/${ticketId}/reorder`, postData)
       .then(response => response.result);
   }
 

--- a/test/web/TicketService.test.js
+++ b/test/web/TicketService.test.js
@@ -1115,9 +1115,37 @@ describe("TicketService", function() {
         done();
       });
     });
-    it('calls the right URL for reorder to be first', function(done) {
+    it('works when the ticket is a Ticket object', function(done) {
+      const ticket = new Qminder.Ticket(12345);
+      Qminder.tickets.reorder(ticket, 12346).then(() => {
+        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 })).toBeTruthy();
+        done();
+      });
+    });
+    it('works when the afterTicket is a Ticket object', function(done) {
+      const afterTicket = new Qminder.Ticket(12346);
+      Qminder.tickets.reorder(12345, afterTicket).then(() => {
+        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 })).toBeTruthy();
+        done();
+      });
+    });
+    it('works when both ticket and afterTicket are Ticket objects', function(done) {
+      const ticket = new Qminder.Ticket(12345);
+      const afterTicket = new Qminder.Ticket(12346);
+      Qminder.tickets.reorder(ticket, afterTicket).then(() => {
+        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 })).toBeTruthy();
+        done();
+      });
+    });
+    it('calls the right URL when reordering to be first', function(done) {
       Qminder.tickets.reorder(12345).then(() => {
-        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: null })).toBeTruthy();
+        expect(this.requestStub.calledWith('tickets/12345/reorder', undefined)).toBeTruthy();
+        done();
+      });
+    });
+    it('omits the after key when reordering to be first (#159)', function(done) {
+      Qminder.tickets.reorder(12345, null).then(() => {
+        expect(this.requestStub.firstCall.args[1]).toBeUndefined();
         done();
       });
     });


### PR DESCRIPTION
This PR makes sure that TicketService#reorder sends the right payload when reordering to be first. Additionally, it makes sure that TicketService#reorder works with Ticket objects as it should.

Fixes #159
Fixes #158