### PR TITLE
Qminder.tickets.reorder always sends a POST now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"

--- a/src/services/TicketService.js
+++ b/src/services/TicketService.js
@@ -971,7 +971,6 @@ export default class TicketService {
 
     let postData: { after: number } = undefined;
     if (afterTicketId) {
-      console.log('afterTicketId is truthy', { afterTicketId });
       postData = {
         after: afterTicketId,
       };
@@ -980,7 +979,7 @@ export default class TicketService {
     if (!ticketId || typeof ticketId !== 'number') {
       throw new Error(ERROR_NO_TICKET_ID);
     }
-    return ApiBase.request(`tickets/${ticketId}/reorder`, postData)
+    return ApiBase.request(`tickets/${ticketId}/reorder`, postData, 'POST')
       .then(response => response.result);
   }
 

--- a/test/web/TicketService.test.js
+++ b/test/web/TicketService.test.js
@@ -1111,21 +1111,21 @@ describe("TicketService", function() {
     });
     it('calls the right URL for reorder after ticket', function(done) {
       Qminder.tickets.reorder(12345, 12346).then(() => {
-        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 })).toBeTruthy();
+        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 }, 'POST')).toBeTruthy();
         done();
       });
     });
     it('works when the ticket is a Ticket object', function(done) {
       const ticket = new Qminder.Ticket(12345);
       Qminder.tickets.reorder(ticket, 12346).then(() => {
-        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 })).toBeTruthy();
+        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 }, 'POST')).toBeTruthy();
         done();
       });
     });
     it('works when the afterTicket is a Ticket object', function(done) {
       const afterTicket = new Qminder.Ticket(12346);
       Qminder.tickets.reorder(12345, afterTicket).then(() => {
-        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 })).toBeTruthy();
+        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 }, 'POST')).toBeTruthy();
         done();
       });
     });
@@ -1133,13 +1133,13 @@ describe("TicketService", function() {
       const ticket = new Qminder.Ticket(12345);
       const afterTicket = new Qminder.Ticket(12346);
       Qminder.tickets.reorder(ticket, afterTicket).then(() => {
-        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 })).toBeTruthy();
+        expect(this.requestStub.calledWith('tickets/12345/reorder', { after: 12346 }, 'POST')).toBeTruthy();
         done();
       });
     });
     it('calls the right URL when reordering to be first', function(done) {
       Qminder.tickets.reorder(12345).then(() => {
-        expect(this.requestStub.calledWith('tickets/12345/reorder', undefined)).toBeTruthy();
+        expect(this.requestStub.calledWith('tickets/12345/reorder', undefined, 'POST')).toBeTruthy();
         done();
       });
     });


### PR DESCRIPTION
This PR makes sure that ApiBase.request sends a POST on Qminder.tickets.reorder, even if the payload is null / undefined.

Fixes #165 