### PR TITLE
TicketService.unassign implementation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1107,6 +1107,12 @@
                       </a></li>
                     
                       <li><a
+                        href='#ticketserviceunassign'
+                        class='regular pre-open'>
+                        .unassign
+                      </a></li>
+                    
+                      <li><a
                         href='#ticketservicereorder'
                         class='regular pre-open'>
                         .reorder
@@ -10016,6 +10022,116 @@ Ticket object.
 </p>
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> tickets: <span class="hljs-built_in">Array</span>&lt;Ticket&gt; = <span class="hljs-keyword">await</span> Qminder.tickets.search({ <span class="hljs-attr">line</span>: <span class="hljs-number">111</span>, <span class="hljs-attr">status</span>: [<span class="hljs-string">'NEW'</span>] });
 tickets.map(<span class="hljs-function">(<span class="hljs-params">ticket: Ticket</span>) =&gt;</span> Qminder.tickets.assign(ticket, <span class="hljs-number">15152</span>));</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='ticketserviceunassign'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>unassign(ticket, unassigner)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Un-assign a ticket. This returns the ticket to the unassigned list.
+This call works only for Tickets that have the status: 'NEW'.</p>
+
+
+  <div class='pre p1 fill-light mt0'>unassign(ticket: (<a href="#ticket">Ticket</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), unassigner: (<a href="#user">User</a> | ticket)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;any></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>ticket</span> <code class='quiet'>((<a href="#ticket">Ticket</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
+	    the ticket object or the ticket's ID that needs un-assignment
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>unassigner</span> <code class='quiet'>((<a href="#user">User</a> | ticket))</code>
+	    the User who un-assigned the ticket, for example current user's ID
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;any></code>:
+        a Promise that resolves when unassigning works and rejects when
+unassigning fails
+
+      
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Using unassign with async/await in latest Javascript/ES6 standard</span>
+<span class="hljs-keyword">const</span> ticketID = <span class="hljs-number">141412345</span>;
+<span class="hljs-keyword">const</span> myUserID = <span class="hljs-number">123</span>;
+<span class="hljs-keyword">try</span> {
+  <span class="hljs-keyword">await</span> Qminder.tickets.unassign(ticketID, myUserID);
+  <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Ticket unassign worked!'</span>);
+} <span class="hljs-keyword">catch</span> (error) {
+  <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Ticket unassign failed'</span>, error);
+}</pre>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Using unassign without async/await, with plain promises.</span>
+<span class="hljs-keyword">const</span> ticketID = <span class="hljs-number">1452521</span>;
+<span class="hljs-keyword">const</span> myUserID = <span class="hljs-number">529</span>;
+Qminder.tickets.unassign(ticketID, myUserID).then(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">success</span>) </span>{
+  <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Ticket unassign worked!'</span>);
+}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">error</span>) </span>{
+  <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Ticket unassign failed!'</span>, error);
+});</pre>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Using unassign with a Ticket object and async/await in latest Javascript/ES6 standard</span>
+<span class="hljs-keyword">const</span> myUserID = <span class="hljs-number">42049</span>;
+<span class="hljs-keyword">const</span> tickets = <span class="hljs-keyword">await</span> Qminder.tickets.search({ <span class="hljs-attr">line</span>: <span class="hljs-number">12345</span> });
+<span class="hljs-keyword">const</span> ticket = tickets[<span class="hljs-number">0</span>];
+<span class="hljs-keyword">await</span> Qminder.tickets.unassign(ticket, myUserID);</pre>
     
   
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"

--- a/src/services/TicketService.js
+++ b/src/services/TicketService.js
@@ -936,6 +936,67 @@ export default class TicketService {
   }
 
   /**
+   * Un-assign a ticket. This returns the ticket to the unassigned list.
+   * This call works only for Tickets that have the status: 'NEW'.
+   * @example
+   * // Using unassign with async/await in latest Javascript/ES6 standard
+   * const ticketID = 141412345;
+   * const myUserID = 123;
+   * try {
+   *   await Qminder.tickets.unassign(ticketID, myUserID);
+   *   console.log('Ticket unassign worked!');
+   * } catch (error) {
+   *   console.log('Ticket unassign failed', error);
+   * }
+   * @example
+   * // Using unassign without async/await, with plain promises.
+   * const ticketID = 1452521;
+   * const myUserID = 529;
+   * Qminder.tickets.unassign(ticketID, myUserID).then(function(success) {
+   *   console.log('Ticket unassign worked!');
+   * }, function(error) {
+   *   console.log('Ticket unassign failed!', error);
+   * });
+   * @example
+   * // Using unassign with a Ticket object and async/await in latest Javascript/ES6 standard
+   * const myUserID = 42049;
+   * const tickets = await Qminder.tickets.search({ line: 12345 });
+   * const ticket = tickets[0];
+   * await Qminder.tickets.unassign(ticket, myUserID);
+   * @param ticket the ticket object or the ticket's ID that needs un-assignment
+   * @param unassigner the User who un-assigned the ticket, for example current user's ID
+   * @returns {Promise<any>} a Promise that resolves when unassigning works and rejects when
+   * unassigning fails
+   */
+  static unassign(ticket: (Ticket|number), unassigner: (User|ticket)): Promise<*> {
+    let ticketId: ?number = null;
+    let unassignerId: ?number = null;
+
+    if (ticket instanceof Ticket) {
+      ticketId = ticket.id;
+    } else {
+      ticketId = ticket;
+    }
+
+    if (!ticketId || typeof ticketId !== 'number') {
+      throw new Error(ERROR_NO_TICKET_ID);
+    }
+
+    if (unassigner instanceof User) {
+      unassignerId = unassigner.id;
+    } else {
+      unassignerId = unassigner;
+    }
+
+    if (!unassignerId || typeof unassignerId !== 'number') {
+      throw new Error('Qminder.tickets.unassign was called without a valid unassigner user.');
+    }
+
+    return ApiBase.request(`tickets/${ticketId}/unassign`, { user: unassignerId }, 'POST')
+      .then(response => response.result);
+  }
+
+  /**
    * Reorder a ticket after another ticket.
    *
    * ```POST /v1/tickets/<ID>/reorder```

--- a/test/web/TicketService.test.js
+++ b/test/web/TicketService.test.js
@@ -1075,33 +1075,76 @@ describe("TicketService", function() {
       expect(() => Qminder.tickets.removeLabel(12345, 'LABEL', 1234)).not.toThrow();
     });
   });
-  describe("assignToUser()", function() {
+  describe("unassign()", function() {
     beforeEach(function() {
       this.requestStub.onCall(0).resolves({
         result: 'success'
       });
     });
     it('calls the right URL with POST and parameters', function(done) {
+      Qminder.tickets.unassign(63020420, 7500).then(() => {
+        expect(this.requestStub.calledWith('tickets/63020420/unassign', { user: 7500 }, 'POST')).toBeTruthy();
+        done();
+      });
+    });
+    it('throws an error when the ticket ID is missing', function() {
+      expect(() => Qminder.tickets.unassign()).toThrow();
+    });
+    it('throws an error when the assigner is missing', function() {
+      expect(() => Qminder.tickets.unassign(63020424)).toThrow();
+    });
+    it('works with User object passed as User parameter', function(done) {
+      const unassigner = new Qminder.User(4100);
+      Qminder.tickets.unassign(63020421, unassigner).then(() => {
+        expect(this.requestStub.calledWith('tickets/63020421/unassign', { user: 4100 }, 'POST')).toBeTruthy();
+        done();
+      });
+    });
+    it('works with Ticket object passed as ticket parameter', function(done) {
+      const ticket = new Qminder.Ticket(60403009);
+      Qminder.tickets.unassign(ticket, 4142).then(() => {
+        expect(this.requestStub.calledWith('tickets/60403009/unassign', { user: 4142 }, 'POST')).toBeTruthy();
+        done();
+      });
+    });
+    it('works with Ticket & User object passed as parameters', function(done) {
+      const unassigner = new Qminder.User(4100);
+      const ticket = new Qminder.Ticket(59430);
+      Qminder.tickets.unassign(ticket, unassigner).then(() => {
+        expect(this.requestStub.calledWith('tickets/59430/unassign', { user: 4100 }, 'POST')).toBeTruthy();
+        done();
+      });
+    });
+    it('throws an error when the unassigner is invalid', function() {
+      expect(() => Qminder.tickets.unassign(63020422, {})).toThrow();
+    });
+    it('throws an error when the response returns an error', function(done) {
+      this.requestStub.restore();
+      this.requestStub.onCall(0).rejects({ status: 400, message: '', developerMessage: '' });
+      Qminder.tickets.unassign(63020422, 4950).then(
+        () => done(new Error('Qminder.tickets.unassign promise should reject but resolved')),
+        () => done());
+    });
+  });
+  describe('unassign()', function() {
+    beforeEach(function() {
+      this.requestStub.onCall(0).resolves({
+        result: 'success'
+      });
+    });
+    it('TODO calls the right URL with POST and parameters', function(done) {
       Qminder.tickets.assignToUser(12345, 41413, 41414).then(() => {
         expect(this.requestStub.calledWith('tickets/12345/assign', { assigner: 41413, assignee: 41414 }, 'POST')).toBeTruthy();
         done();
       });
     });
-    it('throws an error when the ticket ID is missing', function() {
+    it('TODO throws an error when the ticket ID is missing', function() {
       expect(() => Qminder.tickets.assignToUser()).toThrow();
     });
-    it('throws an error when the assigner is missing', function() {
+    it('TODO throws an error when the assigner is missing', function() {
       expect(() => Qminder.tickets.assignToUser(12345)).toThrow();
     });
-    it('throws an error when the assignee missing', function() {
-      expect(() => Qminder.tickets.assignToUser(12345, { id: 41413 })).toThrow();
-    });
-    it('throws an error when the assigner is invalid', function() {
-      expect(() => Qminder.tickets.assignToUser(12345, { id: 41413 }, 1234)).toThrow();
-    });
-    it('throws an error when the assigner is invalid', function() {
-      expect(() => Qminder.tickets.assignToUser(12345, 41413, { id: 1234 })).toThrow();
-    });
+
   });
   describe("reorder()", function() {
     beforeEach(function() {


### PR DESCRIPTION
This PR implements TicketService.unassign.

This means that users can remove visitors being assigned to specific clerks.

Fixes #170 