### PR TITLE
Add isAdmin and isManager to User model

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>qminder-api 2.1.15 | Documentation</title>
+  <title>qminder-api 2.1.17 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>qminder-api</h3>
-          <div class='mb1'><code>2.1.15</code></div>
+          <div class='mb1'><code>2.1.17</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -510,6 +510,12 @@
                       </a></li>
                       
                       <li><a
+                        href='#useremail'
+                        class='regular pre-open'>
+                        #email
+                      </a></li>
+                      
+                      <li><a
                         href='#userfirstname'
                         class='regular pre-open'>
                         #firstName
@@ -522,9 +528,15 @@
                       </a></li>
                       
                       <li><a
-                        href='#useremail'
+                        href='#userdesk'
                         class='regular pre-open'>
-                        #email
+                        #desk
+                      </a></li>
+                      
+                      <li><a
+                        href='#userselectedlocation'
+                        class='regular pre-open'>
+                        #selectedLocation
                       </a></li>
                       
                       <li><a
@@ -534,15 +546,21 @@
                       </a></li>
                       
                       <li><a
-                        href='#userdesk'
-                        class='regular pre-open'>
-                        #desk
-                      </a></li>
-                      
-                      <li><a
                         href='#userroles'
                         class='regular pre-open'>
                         #roles
+                      </a></li>
+                      
+                      <li><a
+                        href='#userisadmin'
+                        class='regular pre-open'>
+                        #isAdmin
+                      </a></li>
+                      
+                      <li><a
+                        href='#userismanager'
+                        class='regular pre-open'>
+                        #isManager
                       </a></li>
                       
                     </ul>
@@ -4673,6 +4691,59 @@ For example, 12345</p>
       </div>
     </div>
   
+    <div class='border-bottom' id='useremail'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>email</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>This user's email address.
+They can use the email address to log in, and to receive Qminder notifications.
+For example: 'jane.smith@example.com'.</p>
+
+
+  <div class='pre p1 fill-light mt0'>email</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
     <div class='border-bottom' id='userfirstname'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
@@ -4777,11 +4848,11 @@ For example, 'Smith'</p>
       </div>
     </div>
   
-    <div class='border-bottom' id='useremail'>
+    <div class='border-bottom' id='userdesk'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>email</span>
+            <span class='code strong strong truncate'>desk</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -4789,16 +4860,65 @@ For example, 'Smith'</p>
 
   
 
-  <p>This user's email address.
-They can use the email address to log in, and to receive Qminder notifications.
-For example: 'jane.smith@example.com'.</p>
+  <p>The user's currently selected desk.</p>
 
 
-  <div class='pre p1 fill-light mt0'>email</div>
+  <div class='pre p1 fill-light mt0'>desk</div>
   
     <p>
       Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='userselectedlocation'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>selectedLocation</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>The user's currently selected location.</p>
+
+
+  <div class='pre p1 fill-light mt0'>selectedLocation</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     </p>
   
   
@@ -4881,57 +5001,6 @@ For example: 'jane.smith@example.com'.</p>
       </div>
     </div>
   
-    <div class='border-bottom' id='userdesk'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>desk</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-
-  <p>The user's currently selected desk.</p>
-
-
-  <div class='pre p1 fill-light mt0'>desk</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
     <div class='border-bottom' id='userroles'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
@@ -4971,6 +5040,172 @@ For example: 'jane.smith@example.com'.</p>
 
   
 
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='userisadmin'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isAdmin()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Returns true if the user is an administrator.
+It uses the user's roles object that can be loaded via Qminder.users.details().
+The user is an administrator when their role list includes an ADMIN role.</p>
+
+
+  <div class='pre p1 fill-light mt0'>isAdmin(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>:
+        true if the user is an administrator, false if they are not.
+
+      
+    
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Throws</div>
+    <ul>
+      
+        <li>any: Error if the user's roles are not loaded.
+</li>
+      
+    </ul>
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Get the details of an user and find out if they are an admin, with ES6 async/await syntax.</span>
+<span class="hljs-keyword">const</span> user = <span class="hljs-keyword">await</span> Qminder.users.details(<span class="hljs-number">1234</span>);
+<span class="hljs-keyword">const</span> isAdmin = user.isAdmin();
+<span class="hljs-built_in">console</span>.log(isAdmin);</pre>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Get the details of an user and find out if they are an admin, in plain JS</span>
+<span class="hljs-comment">// note: this asynchronously loads the user data</span>
+Qminder.users.details(<span class="hljs-number">1234</span>).then(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">user</span>) </span>{
+  <span class="hljs-keyword">const</span> isAdmin = user.isAdmin();
+  <span class="hljs-built_in">console</span>.log(isAdmin);
+});</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='userismanager'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isManager(location)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Returns true if the user is a manager of the given location.
+Looks at the user's roles which can be loaded via Qminder.users.details().</p>
+
+
+  <div class='pre p1 fill-light mt0'>isManager(location: (<a href="#location">Location</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>location</span> <code class='quiet'>((<a href="#location">Location</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
+	    the location to check, for example 6901
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>:
+        true if the user is the manager of the location given
+
+      
+    
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Throws</div>
+    <ul>
+      
+        <li>any: </li>
+      
+    </ul>
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Get the details user 1234 and find out if they are an admin of Location ID 1114, using ES6</span>
+<span class="hljs-comment">// async/await syntax</span>
+<span class="hljs-keyword">const</span> user = <span class="hljs-keyword">await</span> Qminder.users.details(<span class="hljs-number">1234</span>);
+<span class="hljs-keyword">const</span> isManagerOfLocation = user.isManager(<span class="hljs-number">1114</span>);</pre>
+    
   
 
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"

--- a/test/web/User.test.js
+++ b/test/web/User.test.js
@@ -1,0 +1,104 @@
+function getUserWithRoles(roles) {
+  let user = new Qminder.User();
+  user.roles = roles;
+  return user;
+}
+describe("User model", function () {
+  const ADMIN_ROLE = { type: 'ADMIN', id: 14124 };
+  const MANAGER_ROLE = { type: 'MANAGER', id: 14121, location: 12345 };
+  const ANOTHER_MANAGER_ROLE = { type: 'MANAGER', id: 15, location: 1234 };
+  const CLERK_ROLE = { type: 'CLERK', id: 400, location: 12345 };
+
+  beforeEach(function () {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
+    Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
+    Qminder.setServer('local.api.qminderapp.com');
+  });
+
+  describe('isAdmin()', function() {
+    it('returns true if the user is only an admin', function() {
+      const user = getUserWithRoles([ADMIN_ROLE]);
+      expect(user.isAdmin()).toBeTruthy();
+    });
+    it('returns true if the user has two roles, one has admin', function() {
+      const user = getUserWithRoles([ADMIN_ROLE, MANAGER_ROLE]);
+      const anotherUser = getUserWithRoles([MANAGER_ROLE, ADMIN_ROLE]);
+      expect(user.isAdmin()).toBeTruthy();
+      expect(anotherUser.isAdmin()).toBeTruthy();
+    });
+    it('returns false if the user is a clerk', function() {
+      const user = getUserWithRoles([CLERK_ROLE]);
+      expect(user.isAdmin()).toBeFalsy();
+    });
+    it('returns false if the user has one location manager role', function() {
+      const user = getUserWithRoles([MANAGER_ROLE]);
+      expect(user.isAdmin()).toBeFalsy();
+    });
+    it('returns false if the user has multiple location manager roles', function() {
+      const user = getUserWithRoles([MANAGER_ROLE, ANOTHER_MANAGER_ROLE]);
+      expect(user.isAdmin()).toBeFalsy();
+    });
+    it('returns false if the user has mixed clerk/LM roles', function() {
+      const user = getUserWithRoles([MANAGER_ROLE, CLERK_ROLE, ANOTHER_MANAGER_ROLE]);
+      expect(user.isAdmin()).toBeFalsy();
+    });
+    it('throws if user does not have any roles', function() {
+      const user = getUserWithRoles(undefined);
+      expect(() => user.isAdmin()).toThrow();
+    });
+  });
+
+  describe('isManager(location)', function() {
+    it('returns true if the user is only a manager of 12345', function() {
+      const user = getUserWithRoles([MANAGER_ROLE]);
+      expect(user.isManager(12345)).toBeTruthy();
+    });
+    it('returns true if the user has two roles, one of them a manager of 12345', function() {
+      const user = getUserWithRoles([ADMIN_ROLE, MANAGER_ROLE]);
+      const anotherUser = getUserWithRoles([MANAGER_ROLE, ADMIN_ROLE]);
+      expect(user.isManager(12345)).toBeTruthy();
+      expect(anotherUser.isManager(12345)).toBeTruthy();
+    });
+    it('returns false if the user is a clerk', function() {
+      const user = getUserWithRoles([CLERK_ROLE]);
+      expect(user.isManager(12345)).toBeFalsy();
+    });
+    it('returns false if the user has one clerk role', function() {
+      const user = getUserWithRoles([CLERK_ROLE]);
+      expect(user.isManager(12345)).toBeFalsy();
+    });
+    it('returns false if the user has multiple roles but no manager roles', function() {
+      const user = getUserWithRoles([CLERK_ROLE, ADMIN_ROLE]);
+      expect(user.isManager(12345)).toBeFalsy();
+    });
+    it('returns false if the user has mixed clerk/admin roles', function() {
+      const user = getUserWithRoles([CLERK_ROLE, ADMIN_ROLE]);
+      expect(user.isManager(12345)).toBeFalsy();
+    });
+
+    it('works when a Location object is passed', function() {
+      const location = new Qminder.Location();
+      location.id = 12345;
+      const user = getUserWithRoles([CLERK_ROLE, ADMIN_ROLE]);
+      expect(() => user.isManager(12345)).not.toThrow();
+    });
+
+    it('throws when no location is passed', function() {
+      const user = getUserWithRoles([CLERK_ROLE, ADMIN_ROLE]);
+      expect(() => user.isManager()).toThrow();
+    });
+
+    it('throws when an invalid object is passed', function() {
+      const user = getUserWithRoles([CLERK_ROLE, ADMIN_ROLE]);
+      expect(() => user.isManager([])).toThrow();
+      expect(() => user.isManager({})).toThrow();
+      expect(() => user.isManager(Qminder.User)).toThrow();
+      expect(() => user.isManager('hello, world')).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes #172 and brings a couple new useful methods to the User model. 

isAdmin() allows you to verify that a user is the administrator of their Qminder account.

isManager(location: (Location | number)) allows you to check if a user has manager access to a particular location.

Additionally, this PR adds unit tests to both functions, increments the patch version and updating the documentation.