### PR TITLE
Add isOwner to User model as well

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>qminder-api 2.1.17 | Documentation</title>
+  <title>qminder-api 2.1.18 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>qminder-api</h3>
-          <div class='mb1'><code>2.1.17</code></div>
+          <div class='mb1'><code>2.1.18</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -5153,7 +5153,7 @@ Qminder.users.details(<span class="hljs-number">1234</span>).then(<span class="h
 
   <p>Returns true if the user is an Owner.
 It uses the user's roles object that can be loaded via Qminder.users.details().
-The user is an administrator when their role list includes an OWNER role.
+The user is an owner when their role list includes an OWNER role.
 An Owner role can do everything an Admin can, as well as manage billing.</p>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -558,6 +558,12 @@
                       </a></li>
                       
                       <li><a
+                        href='#userisowner'
+                        class='regular pre-open'>
+                        #isOwner
+                      </a></li>
+                      
+                      <li><a
                         href='#userismanager'
                         class='regular pre-open'>
                         #isManager
@@ -5119,6 +5125,88 @@ The user is an administrator when their role list includes an ADMIN role.</p>
 Qminder.users.details(<span class="hljs-number">1234</span>).then(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">user</span>) </span>{
   <span class="hljs-keyword">const</span> isAdmin = user.isAdmin();
   <span class="hljs-built_in">console</span>.log(isAdmin);
+});</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='userisowner'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isOwner()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Returns true if the user is an Owner.
+It uses the user's roles object that can be loaded via Qminder.users.details().
+The user is an administrator when their role list includes an OWNER role.
+An Owner role can do everything an Admin can, as well as manage billing.</p>
+
+
+  <div class='pre p1 fill-light mt0'>isOwner(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>:
+        true if the user is an owner, false if they are not.
+
+      
+    
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Throws</div>
+    <ul>
+      
+        <li>any: Error if the user's roles are not loaded.
+</li>
+      
+    </ul>
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Get the details of an user and find out if they are an owner, with ES6 async/await syntax.</span>
+<span class="hljs-keyword">const</span> user = <span class="hljs-keyword">await</span> Qminder.users.details(<span class="hljs-number">1234</span>);
+<span class="hljs-keyword">const</span> isOwner = user.isOwner();
+<span class="hljs-built_in">console</span>.log(isOwner);</pre>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Get the details of an user and find out if they are an owner, in plain JS</span>
+<span class="hljs-comment">// note: this asynchronously loads the user data</span>
+Qminder.users.details(<span class="hljs-number">1234</span>).then(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">user</span>) </span>{
+  <span class="hljs-keyword">const</span> isOwner = user.isOwner();
+  <span class="hljs-built_in">console</span>.log(isOwner);
 });</pre>
     
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"

--- a/src/model/User.js
+++ b/src/model/User.js
@@ -114,6 +114,34 @@ class User {
   }
 
   /**
+   * Returns true if the user is an Owner.
+   * It uses the user's roles object that can be loaded via Qminder.users.details().
+   * The user is an administrator when their role list includes an OWNER role.
+   * An Owner role can do everything an Admin can, as well as manage billing.
+   * @example
+   * // Get the details of an user and find out if they are an owner, with ES6 async/await syntax.
+   * const user = await Qminder.users.details(1234);
+   * const isOwner = user.isOwner();
+   * console.log(isOwner);
+   * @example
+   * // Get the details of an user and find out if they are an owner, in plain JS
+   * // note: this asynchronously loads the user data
+   * Qminder.users.details(1234).then(function(user) {
+   *   const isOwner = user.isOwner();
+   *   console.log(isOwner);
+   * });
+   * @returns {boolean} true if the user is an owner, false if they are not.
+   * @throws Error if the user's roles are not loaded.
+   */
+  isOwner(): boolean {
+    if (!this.roles) {
+      throw new Error('User roles are not available. Please load the User via Qminder.users.details');
+    }
+    const ownerRole = this.roles.find(role => role && role.type === 'OWNER');
+    return ownerRole !== undefined;
+  }
+
+  /**
    * Returns true if the user is a manager of the given location.
    * Looks at the user's roles which can be loaded via Qminder.users.details().
    * @example

--- a/src/model/User.js
+++ b/src/model/User.js
@@ -116,7 +116,7 @@ class User {
   /**
    * Returns true if the user is an Owner.
    * It uses the user's roles object that can be loaded via Qminder.users.details().
-   * The user is an administrator when their role list includes an OWNER role.
+   * The user is an owner when their role list includes an OWNER role.
    * An Owner role can do everything an Admin can, as well as manage billing.
    * @example
    * // Get the details of an user and find out if they are an owner, with ES6 async/await syntax.

--- a/test/web/User.test.js
+++ b/test/web/User.test.js
@@ -5,6 +5,7 @@ function getUserWithRoles(roles) {
 }
 describe("User model", function () {
   const ADMIN_ROLE = { type: 'ADMIN', id: 14124 };
+  const OWNER_ROLE = { type: 'OWNER', id: 14129 };
   const MANAGER_ROLE = { type: 'MANAGER', id: 14121, location: 12345 };
   const ANOTHER_MANAGER_ROLE = { type: 'MANAGER', id: 15, location: 1234 };
   const CLERK_ROLE = { type: 'CLERK', id: 400, location: 12345 };
@@ -48,6 +49,51 @@ describe("User model", function () {
     it('throws if user does not have any roles', function() {
       const user = getUserWithRoles(undefined);
       expect(() => user.isAdmin()).toThrow();
+    });
+  });
+
+  describe('isOwner()', function() {
+    it('returns true if the user is only an owner', function() {
+      const user = getUserWithRoles([OWNER_ROLE]);
+      expect(user.isOwner()).toBeTruthy();
+    });
+    it('returns true if the user has two roles, one of them Owner', function() {
+      const user = getUserWithRoles([OWNER_ROLE, MANAGER_ROLE]);
+      const anotherUser = getUserWithRoles([MANAGER_ROLE, OWNER_ROLE]);
+      expect(user.isOwner()).toBeTruthy();
+      expect(anotherUser.isOwner()).toBeTruthy();
+    });
+    it('returns false if the user is a clerk', function() {
+      const user = getUserWithRoles([CLERK_ROLE]);
+      expect(user.isOwner()).toBeFalsy();
+    });
+    it('returns false if the user has one location manager role', function() {
+      const user = getUserWithRoles([MANAGER_ROLE]);
+      expect(user.isOwner()).toBeFalsy();
+    });
+    it('returns false if the user has multiple location manager roles', function() {
+      const user = getUserWithRoles([MANAGER_ROLE, ANOTHER_MANAGER_ROLE]);
+      expect(user.isOwner()).toBeFalsy();
+    });
+    it('returns false if the user has mixed clerk/LM roles', function() {
+      const user = getUserWithRoles([MANAGER_ROLE, CLERK_ROLE, ANOTHER_MANAGER_ROLE]);
+      expect(user.isOwner()).toBeFalsy();
+    });
+    it('returns false if the user is an admin', function() {
+      const user = getUserWithRoles([ADMIN_ROLE]);
+      expect(user.isOwner()).toBeFalsy();
+    });
+    it('returns false if the user has mixed clerk/LM/Admin roles', function() {
+      const user = getUserWithRoles([MANAGER_ROLE, CLERK_ROLE, ANOTHER_MANAGER_ROLE, ADMIN_ROLE]);
+      expect(user.isOwner()).toBeFalsy();
+    });
+    it('returns true if the user has mixed clerk/LM/owner roles', function() {
+      const user = getUserWithRoles([MANAGER_ROLE, CLERK_ROLE, ANOTHER_MANAGER_ROLE, OWNER_ROLE]);
+      expect(user.isOwner()).toBeTruthy();
+    });
+    it('throws if user does not have any roles', function() {
+      const user = getUserWithRoles(undefined);
+      expect(() => user.isOwner()).toThrow();
     });
   });
 


### PR DESCRIPTION
This PR adds a third utility function to the User model: isOwner().

Now, in order to check if a user has enough administrative privileges to perform certain actions, this logical clause should be used:

    user.isAdmin() || user.isOwner()

In order to check access to owner-only actions, this clause can be used:

    user.isOwner()

Fixes #175 