### PR TITLE
GraphQL API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build-web
 build-es6
 node_modules
 docs
+
+# IDEA GraphQL plugin config
+graphql.config.json

--- a/DEVELOPMENT.txt
+++ b/DEVELOPMENT.txt
@@ -1,6 +1,0 @@
-Running tests:
-=================================
-$ brew install node
-$ npm install -g grunt-cli
-$ npm install
-$ QMINDER_SECRET_KEY=XXX grunt tests --verbose

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ For starters, you can find all tickets in a line with ID 12345:
 Qminder.tickets refers to TicketService, for which you can find documentation in the 
 [API reference][api].
 
+Alternatively, you can send a [GraphQL](https://graphql.org/) query to the Qminder API:
+
+    const locations = await Qminder.graphql(`{
+        locations {
+            id
+            name
+        }
+    }`);
+
+The GraphQL API is self-documenting. Specialized query tools and IDE integrations can 
+automatically query the API schema and validate queries before they are sent.
+
 ### Testing changes to Javascript API in another project
 
 When contributing to the JS API, you may wish to test if it works in a project that utilizes the API

--- a/docs/index.html
+++ b/docs/index.html
@@ -1291,6 +1291,34 @@
                 
                 </li>
               
+                
+                <li><a
+                  href='#graphqlservice'
+                  class=" toggle-sibling">
+                  GraphQLService
+                  <span class='icon'>▸</span>
+                </a>
+                
+                <div class='toggle-target display-none'>
+                  
+                  <ul class='list-reset py1-ul pl1'>
+                    <li class='h5'><span>Static members</span></li>
+                    
+                      <li><a
+                        href='#graphqlservicequery'
+                        class='regular pre-open'>
+                        .query
+                      </a></li>
+                    
+                    </ul>
+                  
+                  
+                  
+                  
+                </div>
+                
+                </li>
+              
             </ul>
           </div>
           <div class='mt1 h6 quiet'>
@@ -12080,6 +12108,166 @@ list of webhooks in the Qminder Dashboard.</p>
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> url = <span class="hljs-string">'https://example.com/webhooks/qminder'</span>;
 <span class="hljs-keyword">const</span> webhook: Webhook = <span class="hljs-keyword">await</span> Qminder.webhooks.create(url);
 <span class="hljs-keyword">await</span> Qminder.webhooks.remove(webhook);</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='graphqlservice'>
+      GraphQLService
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>A service that lets the user query Qminder API via GraphQL statements.</p>
+
+
+  <div class='pre p1 fill-light mt0'>new GraphQLService()</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Static Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='graphqlservicequery'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>query(query, variables)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Query Qminder API with GraphQL</p>
+<p>Send a GraphQL query to the Qminder API.</p>
+<p>When the query contains variables, make sure to fill them all in the second parameter.</p>
+
+
+  <div class='pre p1 fill-light mt0'>query(query: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, variables: {}): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>query</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    required: the query to send, for example '{ me { selectedLocation } }'
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>variables</span> <code class='quiet'>({})</code>
+	    optional: additional variables for the query
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>></code>:
+        a promise that resolves to the query's results, or rejects if the query failed
+
+      
+    
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Throws</div>
+    <ul>
+      
+        <li>any: when the 'query' argument is undefined or an empty string
+</li>
+      
+    </ul>
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Figure out the selected location ID of the current user, with async/await</span>
+<span class="hljs-keyword">try</span> {
+    <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> Qminder.graphql(<span class="hljs-string">`{ me { selectedLocation } }`</span>);
+    <span class="hljs-built_in">console</span>.log(response.me.selectedLocation); <span class="hljs-comment">// "12345"</span>
+} <span class="hljs-keyword">catch</span> (error) {
+    <span class="hljs-built_in">console</span>.log(error);
+}</pre>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Figure out the selected location ID of the current user, with promises</span>
+Qminder.graphql(<span class="hljs-string">"{ me { selectedLocation } }"</span>).then(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">response</span>) </span>{
+    <span class="hljs-built_in">console</span>.log(response.me.selectedLocation);
+}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">error</span>) </span>{
+    <span class="hljs-built_in">console</span>.log(error);
+});</pre>
     
   
 

--- a/examples/graphql/all_location_names.graphql
+++ b/examples/graphql/all_location_names.graphql
@@ -1,0 +1,5 @@
+{
+  locations {
+    name
+  }
+}

--- a/examples/graphql/lines_for_location.graphql
+++ b/examples/graphql/lines_for_location.graphql
@@ -1,0 +1,8 @@
+query location($id: String!){
+    location(id: $id) {
+      lines {
+          id
+          name
+      }
+  }
+}

--- a/examples/graphql/location_list.js
+++ b/examples/graphql/location_list.js
@@ -1,0 +1,70 @@
+/**
+ * An example of running GraphQL queries in a Node.js script.
+ *
+ * To run this script, make sure you have Node version 7.10.1 or up (because it uses async/await
+ * syntax). You can check by running `node --version`.
+ *
+ * Then, get the API key for your Account:
+ *
+ *     # In Unix/Linux-based operating systems:
+ *     export API_KEY=123456789012345678901234567
+ *     # In Windows:
+ *     set API_KEY=123456789012345678901234567
+ *
+ * Third, make sure the API is compiled:
+ *
+ *     npm run build-node
+ *
+ * Finally, run the script:
+ *
+ *     node location_list.js
+ */
+
+const Qminder = require('../../build-node/qminder-api');
+
+Qminder.setKey(process.env.API_KEY);
+
+async function getLocations() {
+  try {
+    const result = await Qminder.graphql(`{
+       locations {
+         id
+         name
+       }
+    }`);
+
+    if (result.errors && result.errors.length > 0) {
+      /**
+       * result = {
+       *   "statusCode": 200,
+       *   "errors": [
+       *     { "message": "Validation error of /.../", ... }
+       *   ],
+       *   "dataPresent": false
+       * };
+       */
+      console.log(result.errors);
+      return;
+    }
+
+    /**
+     * result = {
+     *   "statusCode": 200,
+     *   "errors": [],
+     *   "data": {
+     *     "locations": [
+     *       { "id": 14205, "name": "Service Center" },
+     *       { "id": 14214, "name": "HQ" },
+     *       { "id": 14399, "name": "London Branch" },
+     *     ]
+     *   },
+     *   "dataPresent": true
+     * }
+     */
+    console.log('Locations: ', result.data.locations.map(location => location.name));
+  } catch (err) {
+    console.error('Error: ', err);
+  }
+}
+
+getLocations();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"

--- a/src/api-base.js
+++ b/src/api-base.js
@@ -96,6 +96,45 @@ class ApiBase {
              return responseJson;
            });
   }
+
+  /**
+   * Send a GraphQL query to the Qminder API.
+   *
+   * Sends the given query to the Qminder API, returning a Promise that resolves to the site's HTTP
+   * response.
+   * @param query required: he GraphQL query, for example "{ me { email } }", or
+   * "query X($id: ID!) { location($id) { name } }"
+   * @param variables optional: the GraphQL query's variables, for example { id: "4" }
+   * @returns a Promise that resolves to the entire response ({ statusCode, data?, errors? ... })
+   * @throws when the API key is missing
+   * @throws when the query is undefined or an empty string
+   */
+  queryGraph(query: string, variables?: { [string]: any }): Promise<Object> {
+    if (!query) {
+      throw new Error('ApiBase.queryGraph expected a query as its first argument.');
+    }
+    if (!this.apiKey) {
+      throw new Error('Please set the API key before making any requests.');
+    }
+
+    const requestBody: { query: string, variables?: { [string]: any }} = { query };
+
+    if (variables) {
+      requestBody.variables = variables;
+    }
+
+    const init: RequestOptions = {
+      method: 'POST',
+      headers: {
+        'X-Qminder-REST-API-Key': this.apiKey,
+      },
+      mode: 'cors',
+      body: JSON.stringify(requestBody),
+    };
+
+    return this.fetch(`https://${this.apiServer}/graphql`, init)
+      .then(response => response.json());
+  }
 }
 
 export default new ApiBase();

--- a/src/qminder-api.js
+++ b/src/qminder-api.js
@@ -16,6 +16,7 @@ import LocationService from './services/LocationService';
 import TicketService from './services/TicketService';
 import UserService from './services/UserService';
 import WebhooksService from './services/WebhooksService';
+import GraphQLService from './services/GraphQLService';
 
 /**
  * Set the Qminder API key.
@@ -40,6 +41,9 @@ const setServer = (server: string) => {
 // VERSION is replaced with the version string from package.json during compile time
 const qminderVersion = VERSION;
 
+const graphql = GraphQLService.query;
+
+
 export {
   DeviceService as devices,
   EventsService as events,
@@ -48,10 +52,10 @@ export {
   TicketService as tickets,
   UserService as users,
   WebhooksService as webhooks,
-
   qminderVersion as version,
   setKey,
   setServer,
+  graphql,
 
   ApiBase,
   Desk,

--- a/src/services/GraphQLService.js
+++ b/src/services/GraphQLService.js
@@ -1,0 +1,42 @@
+// @flow
+
+import ApiBase from '../api-base';
+
+/**
+ * A service that lets the user query Qminder API via GraphQL statements.
+ */
+export default class GraphQLService {
+  /**
+   * Query Qminder API with GraphQL
+   *
+   * Send a GraphQL query to the Qminder API.
+   *
+   * When the query contains variables, make sure to fill them all in the second parameter.
+   *
+   * @example
+   * // Figure out the selected location ID of the current user, with async/await
+   * try {
+   *     const response = await Qminder.graphql(`{ me { selectedLocation } }`);
+   *     console.log(response.me.selectedLocation); // "12345"
+   * } catch (error) {
+   *     console.log(error);
+   * }
+   * @example
+   * // Figure out the selected location ID of the current user, with promises
+   * Qminder.graphql("{ me { selectedLocation } }").then(function(response) {
+   *     console.log(response.me.selectedLocation);
+   * }, function(error) {
+   *     console.log(error);
+   * });
+   * @param query required: the query to send, for example '{ me { selectedLocation } }'
+   * @param variables optional: additional variables for the query
+   * @returns a promise that resolves to the query's results, or rejects if the query failed
+   * @throws when the 'query' argument is undefined or an empty string
+   */
+  static query(query: string, variables?: { [string]: any }): Promise<Object> {
+    if (!query || query.length === 0) {
+      throw new Error('GraphQLService query expects a GraphQL query as its first argument');
+    }
+    return ApiBase.queryGraph(query, variables);
+  }
+}

--- a/test/web/GraphQLService.test.js
+++ b/test/web/GraphQLService.test.js
@@ -1,0 +1,52 @@
+describe("GraphQLService", function() {
+  const ME_ID_REQUEST = '{ me { id } }';
+  const ME_ID_SUCCESS_RESPONSE = {
+    statusCode: 200,
+    errors: [],
+    data: {
+      me: {
+        id: 123456
+      }
+    }
+  };
+  beforeEach(function() {
+    if (typeof Qminder === 'undefined') {
+      Qminder = this.Qminder;
+    }
+    if (typeof sinon === 'undefined') {
+      sinon = this.sinon;
+    }
+    Qminder.setKey('F7arvJSi0ycoT2mDRq63blBofBU3LxrnVVqCLxhn');
+    Qminder.setServer('local.api.qminderapp.com');
+
+    // Stub ApiBase.request to feed specific data to API
+    this.requestStub = sinon.stub(Qminder.ApiBase, 'queryGraph');
+  });
+
+  describe("Qminder.graphql", function() {
+    beforeEach(function() {
+      this.requestStub.onFirstCall().resolves(ME_ID_SUCCESS_RESPONSE);
+    });
+    it('calls ApiBase.queryGraph with the correct parameters', function() {
+      Qminder.graphql(ME_ID_REQUEST).then(() => {
+        expect(this.requestStub.calledWith(ME_ID_REQUEST, undefined)).toBeTruthy();
+      });
+    });
+    it('calls ApiBase.queryGraph with both query & variables', function() {
+      const variables = { x: 5, y: 4 };
+      Qminder.graphql(ME_ID_REQUEST, variables).then(() => {
+        expect(this.requestStub.calledWith(ME_ID_REQUEST, variables)).toBeTruthy();
+      });
+    });
+
+    it('throws when query is missing', function() {
+      expect(() => Qminder.graphql()).toThrow();
+      expect(this.requestStub.callCount).toBe(0);
+    });
+
+  });
+
+  afterEach(function() {
+    Qminder.ApiBase.queryGraph.restore();
+  });
+});


### PR DESCRIPTION
This PR implements a new service to conveniently access our GraphQL API. Currently it only defines one method, just to send raw queries to GraphQL.

How to use:

```js
// 1. Actually call the API
const response = await Qminder.graphql(`{ locations { id } }`);
// 2. API returns the full GraphQL response, including errors, status code & data.
if (response.dataIsPresent) {
    console.log(response.data.locations); 
} else {
    console.error(response.errors);
}
```