### PR TITLE
Mark "random: false" in karma.conf, and remove a logging line.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -76,9 +76,14 @@ module.exports = function(config) {
       },
     },
 
-    // NOTE: set it to true to see log statements from the browser.
     client: {
-      captureConsole: false
+      // NOTE: set it to true to see log statements from the browser.
+      captureConsole: false,
+
+      // This is needed to make sure setup & teardown sections run in sequence, for some reason.
+      jasmine: {
+        random: false
+      }
     },
 
 

--- a/src/api-base.ts
+++ b/src/api-base.ts
@@ -106,7 +106,6 @@ class ApiBase {
     if (typeof (fetch as any).default === 'function') {
       this.fetch = ((fetch as any).default as Function);
     }
-    console.log('Fetch instantiated!', this.fetch);
     this.setServer('api.qminder.com');
   }
 


### PR DESCRIPTION
Fixes #179 

It seems that our tests are currently order specific. This should be changed, since tests should be atomic and all that. The tests have been written in an atomic fashion, however the issue that we're facing with random ordered tests is that some tests try to Stub a method that has been currently stubbed by a different test.

This could be fixed by loading a fresh Qminder object somehow for every test (or having Karma reload the page after every test, or similar measures). In Node.js, the require.cache could be cleared and the object loaded again.