### PR TITLE
Allow resetting first & last name & phone number by sending null in TicketService.edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"

--- a/src/services/TicketService.ts
+++ b/src/services/TicketService.ts
@@ -571,19 +571,19 @@ export default class TicketService {
     }
 
     const params: TicketEditingRequest = {};
-    if (changes.firstName) {
+    if (Object.prototype.hasOwnProperty.call(changes, 'firstName')) {
       params.firstName = changes.firstName;
     }
-    if (changes.lastName) {
+    if (Object.prototype.hasOwnProperty.call(changes, 'lastName')) {
       params.lastName = changes.lastName;
     }
-    if (changes.phoneNumber) {
+    if (Object.prototype.hasOwnProperty.call(changes, 'phoneNumber')) {
       params.phoneNumber = changes.phoneNumber;
     }
-    if (changes.line) {
+    if (Object.prototype.hasOwnProperty.call(changes, 'line')) {
       params.line = changes.line;
     }
-    if (changes.extra) {
+    if (Object.prototype.hasOwnProperty.call(changes, 'extra')) {
       params.extra = JSON.stringify(changes.extra);
     }
 

--- a/test/web/TicketService.test.js
+++ b/test/web/TicketService.test.js
@@ -668,6 +668,36 @@ describe("TicketService", function() {
       expect(() => Qminder.tickets.edit(new Qminder.Ticket({}))).toThrow();
     });
 
+    it('allows resetting first name to empty with empty string', function() {
+      Qminder.tickets.edit(12345, { firstName: '' });
+      expect(this.requestStub.calledWith('tickets/12345/edit',
+                                sinon.match({ firstName: '' }))).toBeTruthy();
+    });
+
+    it('allows resetting last name to empty with empty string', function() {
+      Qminder.tickets.edit(12345, { lastName: '' });
+      expect(this.requestStub.calledWith('tickets/12345/edit',
+        sinon.match({ lastName: '' }))).toBeTruthy();
+    });
+
+    it('allows resetting first name to empty with null', function() {
+      Qminder.tickets.edit(12345, { firstName: null });
+      expect(this.requestStub.calledWith('tickets/12345/edit',
+        sinon.match({ firstName: null }))).toBeTruthy();
+    });
+
+    it('allows resetting last name to empty with null', function() {
+      Qminder.tickets.edit(12345, { lastName: null });
+      expect(this.requestStub.calledWith('tickets/12345/edit',
+        sinon.match({ lastName: null }))).toBeTruthy();
+    });
+
+    it('allows resetting phone number to empty with null', function() {
+      Qminder.tickets.edit(12345, { phoneNumber: null });
+      expect(this.requestStub.calledWith('tickets/12345/edit',
+        sinon.match({ phoneNumber: null }))).toBeTruthy();
+    });
+
     it('Sends the extras as a JSON array', function() {
       const changes = {
         phoneNumber: 3185551234,


### PR DESCRIPTION
This PR fixes #181, making sure that tickets can be edited to clear the first or last name or phone number like this.

It also adds regression tests for all of the cases, so that unit tests can catch the bug as well.


```javascript
Qminder.tickets.edit(12345, { firstName: '' });
```

Or this:

```javascript
Qminder.tickets.edit(12345, { firstName: null });
```
