### PR TITLE
Don't automatically parseInt ticket IDs

### DIFF
--- a/docs/classes/_model_desk_.desk.html
+++ b/docs/classes/_model_desk_.desk.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Desk.ts#L26">model/Desk.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Desk.ts#L26">model/Desk.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Desk.ts#L19">model/Desk.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Desk.ts#L19">model/Desk.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Desk.ts#L26">model/Desk.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Desk.ts#L26">model/Desk.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/_model_device_.device.html
+++ b/docs/classes/_model_device_.device.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Device.ts#L52">model/Device.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Device.ts#L52">model/Device.ts:52</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">battery<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Device.ts#L49">model/Device.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Device.ts#L49">model/Device.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Device.ts#L7">model/Device.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Device.ts#L7">model/Device.ts:7</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Device.ts#L26">model/Device.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Device.ts#L26">model/Device.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">needs<wbr>Update<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Device.ts#L32">model/Device.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Device.ts#L32">model/Device.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">offline<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Device.ts#L29">model/Device.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Device.ts#L29">model/Device.ts:29</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"MONITOR"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"OVERVIEW_MONITOR"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"PRINTER"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"NAME_DEVICE"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Device.ts#L23">model/Device.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Device.ts#L23">model/Device.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/_model_line_.line.html
+++ b/docs/classes/_model_line_.line.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Line.ts#L32">model/Line.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Line.ts#L32">model/Line.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Line.ts#L27">model/Line.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Line.ts#L27">model/Line.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">disabled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Line.ts#L32">model/Line.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Line.ts#L32">model/Line.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Line.ts#L16">model/Line.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Line.ts#L16">model/Line.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Line.ts#L22">model/Line.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Line.ts#L22">model/Line.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/_model_location_.location.html
+++ b/docs/classes/_model_location_.location.html
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L36">model/Location.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L36">model/Location.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">country<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L36">model/Location.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L36">model/Location.ts:36</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L10">model/Location.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L10">model/Location.ts:10</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">latitude<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L25">model/Location.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L25">model/Location.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">longitude<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L30">model/Location.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L30">model/Location.ts:30</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L14">model/Location.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L14">model/Location.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">timezone<wbr>Offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L20">model/Location.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L20">model/Location.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/_model_ticket_.ticket.html
+++ b/docs/classes/_model_ticket_.ticket.html
@@ -136,19 +136,19 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Ticket<span class="tsd-signature-symbol">(</span>properties<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><a href="_model_ticket_.ticket.html" class="tsd-signature-type">Ticket</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_model_ticket_.ticket.html" class="tsd-signature-type">Ticket</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Ticket<span class="tsd-signature-symbol">(</span>properties<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="_model_ticket_.ticket.html" class="tsd-signature-type">Ticket</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_model_ticket_.ticket.html" class="tsd-signature-type">Ticket</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L162">model/Ticket.ts:162</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L162">model/Ticket.ts:162</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>properties: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><a href="_model_ticket_.ticket.html" class="tsd-signature-type">Ticket</a></h5>
+									<h5>properties: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="_model_ticket_.ticket.html" class="tsd-signature-type">Ticket</a></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="_model_ticket_.ticket.html" class="tsd-signature-type">Ticket</a></h4>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">assigned<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L123">model/Ticket.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L123">model/Ticket.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">called<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L98">model/Ticket.ts:98</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L98">model/Ticket.ts:98</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancelled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L134">model/Ticket.ts:134</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L134">model/Ticket.ts:134</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L88">model/Ticket.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L88">model/Ticket.ts:88</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 					<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L61">model/Ticket.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L61">model/Ticket.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -280,7 +280,7 @@
 					<div class="tsd-signature tsd-kind-icon">extra<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_ticket_.html#ticketextra" class="tsd-signature-type">TicketExtra</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L143">model/Ticket.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L143">model/Ticket.ts:143</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -300,7 +300,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L55">model/Ticket.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L55">model/Ticket.ts:55</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -312,10 +312,10 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="id" class="tsd-anchor"></a>
 					<h3>id</h3>
-					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
+					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L22">model/Ticket.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L22">model/Ticket.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -330,7 +330,7 @@
 					<div class="tsd-signature tsd-kind-icon">interactions<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_ticket_.html#ticketinteraction" class="tsd-signature-type">TicketInteraction</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L156">model/Ticket.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L156">model/Ticket.ts:156</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -350,7 +350,7 @@
 					<div class="tsd-signature tsd-kind-icon">labels<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_ticket_.html#ticketlabel" class="tsd-signature-type">TicketLabel</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L149">model/Ticket.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L149">model/Ticket.ts:149</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -370,7 +370,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L57">model/Ticket.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L57">model/Ticket.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -385,7 +385,7 @@
 					<div class="tsd-signature tsd-kind-icon">line<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L52">model/Ticket.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L52">model/Ticket.ts:52</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -401,7 +401,7 @@
 					<div class="tsd-signature tsd-kind-icon">messages<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_ticket_.html#ticketmessage" class="tsd-signature-type">TicketMessage</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L162">model/Ticket.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L162">model/Ticket.ts:162</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -421,7 +421,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L30">model/Ticket.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L30">model/Ticket.ts:30</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -441,7 +441,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>After<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L80">model/Ticket.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L80">model/Ticket.ts:80</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -466,7 +466,7 @@
 					<div class="tsd-signature tsd-kind-icon">phone<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L59">model/Ticket.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L59">model/Ticket.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -481,7 +481,7 @@
 					<div class="tsd-signature tsd-kind-icon">served<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L106">model/Ticket.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L106">model/Ticket.ts:106</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -505,7 +505,7 @@
 					<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"PHONE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"MANUAL"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"NAME"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"PRINTER"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L46">model/Ticket.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L46">model/Ticket.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -524,7 +524,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_ticket_.html#ticketstatus" class="tsd-signature-type">TicketStatus</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L36">model/Ticket.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L36">model/Ticket.ts:36</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/_model_user_.user.html
+++ b/docs/classes/_model_user_.user.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L75">model/User.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L75">model/User.ts:75</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">desk<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L63">model/User.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L63">model/User.ts:63</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L49">model/User.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L49">model/User.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L54">model/User.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L54">model/User.ts:54</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -213,7 +213,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L43">model/User.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L43">model/User.ts:43</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L59">model/User.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L59">model/User.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -245,7 +245,7 @@
 					<div class="tsd-signature tsd-kind-icon">picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_model_user_.html#picture" class="tsd-signature-type">Picture</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L71">model/User.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L71">model/User.ts:71</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">roles<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/_model_user_.userrole.html" class="tsd-signature-type">UserRole</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L75">model/User.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L75">model/User.ts:75</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 					<div class="tsd-signature tsd-kind-icon">selected<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L67">model/User.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L67">model/User.ts:67</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L107">model/User.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L107">model/User.ts:107</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -341,7 +341,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L155">model/User.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L155">model/User.ts:155</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -384,7 +384,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L135">model/User.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L135">model/User.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_model_webhook_.webhook.html
+++ b/docs/classes/_model_webhook_.webhook.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Webhook.ts#L7">model/Webhook.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Webhook.ts#L7">model/Webhook.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Webhook.ts#L6">model/Webhook.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Webhook.ts#L6">model/Webhook.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Webhook.ts#L7">model/Webhook.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Webhook.ts#L7">model/Webhook.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/_services_deviceservice_.deviceservice.html
+++ b/docs/classes/_services_deviceservice_.deviceservice.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/DeviceService.ts#L57">services/DeviceService.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/DeviceService.ts#L57">services/DeviceService.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/DeviceService.ts#L85">services/DeviceService.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/DeviceService.ts#L85">services/DeviceService.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@ device = <span class="hljs-keyword">await</span> Qminder.devices.edit(device, de
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/DeviceService.ts#L30">services/DeviceService.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/DeviceService.ts#L30">services/DeviceService.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -255,7 +255,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/DeviceService.ts#L116">services/DeviceService.ts:116</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/DeviceService.ts#L116">services/DeviceService.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_services_eventsservice_.eventsservice.html
+++ b/docs/classes/_services_eventsservice_.eventsservice.html
@@ -140,7 +140,7 @@ Qminder.events.onTicketCalled(<span class="hljs-function"><span class="hljs-para
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L123">services/EventsService.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L123">services/EventsService.ts:123</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@ Qminder.events.onTicketCalled(<span class="hljs-function"><span class="hljs-para
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L150">services/EventsService.ts:150</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L150">services/EventsService.ts:150</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -220,7 +220,7 @@ Qminder.events.onConnect(<span class="hljs-function"><span class="hljs-params">(
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L172">services/EventsService.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L172">services/EventsService.ts:172</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@ Qminder.events.onDisconnect(<span class="hljs-function"><span class="hljs-keywor
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L582">services/EventsService.ts:582</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L582">services/EventsService.ts:582</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -314,7 +314,7 @@ Qminder.events.onLinesChanged(<span class="hljs-function"><span class="hljs-keyw
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L602">services/EventsService.ts:602</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L602">services/EventsService.ts:602</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@ Qminder.events.onLocationChanged(<span class="hljs-function"><span class="hljs-k
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L545">services/EventsService.ts:545</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L545">services/EventsService.ts:545</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -403,7 +403,7 @@ Qminder.events.onOverviewMonitorChanged(<span class="hljs-function"><span class=
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L564">services/EventsService.ts:564</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L564">services/EventsService.ts:564</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -447,7 +447,7 @@ Qminder.events.onSignInDeviceChanged(<span class="hljs-function"><span class="hl
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L421">services/EventsService.ts:421</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L421">services/EventsService.ts:421</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -498,7 +498,7 @@ Qminder.events.onSignInDeviceChanged(<span class="hljs-function"><span class="hl
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L472">services/EventsService.ts:472</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L472">services/EventsService.ts:472</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -550,7 +550,7 @@ Qminder.events.onTicketCancelled(<span class="hljs-function"><span class="hljs-k
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L526">services/EventsService.ts:526</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L526">services/EventsService.ts:526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -602,7 +602,7 @@ Qminder.events.onTicketChanged(<span class="hljs-function"><span class="hljs-key
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L397">services/EventsService.ts:397</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L397">services/EventsService.ts:397</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -654,7 +654,7 @@ Qminder.events.onTicketCreated(<span class="hljs-function"><span class="hljs-key
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L445">services/EventsService.ts:445</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L445">services/EventsService.ts:445</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -705,7 +705,7 @@ Qminder.events.onTicketCreated(<span class="hljs-function"><span class="hljs-key
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L499">services/EventsService.ts:499</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L499">services/EventsService.ts:499</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_services_graphqlservice_.graphqlservice.html
+++ b/docs/classes/_services_graphqlservice_.graphqlservice.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/GraphQLService.ts#L42">services/GraphQLService.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/GraphQLService.ts#L42">services/GraphQLService.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_services_lineservice_.lineservice.html
+++ b/docs/classes/_services_lineservice_.lineservice.html
@@ -121,7 +121,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_GOES_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/LineService.ts#L82">services/LineService.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/LineService.ts#L82">services/LineService.ts:82</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -165,7 +165,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_GOES_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/LineService.ts#L57">services/LineService.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/LineService.ts#L57">services/LineService.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -201,7 +201,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_GOES_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/LineService.ts#L35">services/LineService.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/LineService.ts#L35">services/LineService.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -238,7 +238,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_GOES_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/LineService.ts#L112">services/LineService.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/LineService.ts#L112">services/LineService.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_services_locationservice_.locationservice.html
+++ b/docs/classes/_services_locationservice_.locationservice.html
@@ -120,7 +120,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_GOES_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/LocationService.ts#L64">services/LocationService.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/LocationService.ts#L64">services/LocationService.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -161,7 +161,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/LocationService.ts#L87">services/LocationService.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/LocationService.ts#L87">services/LocationService.ts:87</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/LocationService.ts#L115">services/LocationService.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/LocationService.ts#L115">services/LocationService.ts:115</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/LocationService.ts#L40">services/LocationService.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/LocationService.ts#L40">services/LocationService.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_services_ticketservice_.ticketservice.html
+++ b/docs/classes/_services_ticketservice_.ticketservice.html
@@ -160,7 +160,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L940">services/TicketService.ts:940</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L940">services/TicketService.ts:940</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -217,7 +217,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1068">services/TicketService.ts:1068</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1068">services/TicketService.ts:1068</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -279,7 +279,7 @@ tickets.map(<span class="hljs-function">(<span class="hljs-params">ticket: Ticke
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L693">services/TicketService.ts:693</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L693">services/TicketService.ts:693</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -329,7 +329,7 @@ tickets.map(<span class="hljs-function">(<span class="hljs-params">ticket: Ticke
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L617">services/TicketService.ts:617</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L617">services/TicketService.ts:617</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -378,7 +378,7 @@ tickets.map(<span class="hljs-function">(<span class="hljs-params">ticket: Ticke
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L834">services/TicketService.ts:834</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L834">services/TicketService.ts:834</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -420,7 +420,7 @@ tickets.map(<span class="hljs-function">(<span class="hljs-params">ticket: Ticke
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L389">services/TicketService.ts:389</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L389">services/TicketService.ts:389</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -463,7 +463,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L460">services/TicketService.ts:460</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L460">services/TicketService.ts:460</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -541,7 +541,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L520">services/TicketService.ts:520</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L520">services/TicketService.ts:520</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -588,7 +588,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L558">services/TicketService.ts:558</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L558">services/TicketService.ts:558</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -644,7 +644,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1460">services/TicketService.ts:1460</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1460">services/TicketService.ts:1460</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -719,7 +719,7 @@ Qminder.tickets.search({ <span class="hljs-attr">status</span>: [<span class="hl
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1285">services/TicketService.ts:1285</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1285">services/TicketService.ts:1285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -754,7 +754,7 @@ Qminder.tickets.search({ <span class="hljs-attr">status</span>: [<span class="hl
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1259">services/TicketService.ts:1259</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1259">services/TicketService.ts:1259</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -798,7 +798,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1334">services/TicketService.ts:1334</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1334">services/TicketService.ts:1334</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -857,7 +857,7 @@ Qminder.tickets.getMessages(<span class="hljs-number">12345678</span>).then(<spa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L806">services/TicketService.ts:806</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L806">services/TicketService.ts:806</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -893,7 +893,7 @@ Qminder.tickets.getMessages(<span class="hljs-number">12345678</span>).then(<spa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L777">services/TicketService.ts:777</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L777">services/TicketService.ts:777</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -928,7 +928,7 @@ Qminder.tickets.getMessages(<span class="hljs-number">12345678</span>).then(<spa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L750">services/TicketService.ts:750</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L750">services/TicketService.ts:750</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -962,7 +962,7 @@ Qminder.tickets.getMessages(<span class="hljs-number">12345678</span>).then(<spa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1002">services/TicketService.ts:1002</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1002">services/TicketService.ts:1002</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1019,7 +1019,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1208">services/TicketService.ts:1208</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1208">services/TicketService.ts:1208</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1072,7 +1072,7 @@ Qminder.tickets.reorder(ticket3, ticket1);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L882">services/TicketService.ts:882</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L882">services/TicketService.ts:882</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1125,7 +1125,7 @@ Qminder.tickets.reorder(ticket3, ticket1);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L345">services/TicketService.ts:345</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L345">services/TicketService.ts:345</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1189,7 +1189,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1383">services/TicketService.ts:1383</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1383">services/TicketService.ts:1383</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1256,7 +1256,7 @@ Qminder.tickets.sendMessage(
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L1155">services/TicketService.ts:1155</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L1155">services/TicketService.ts:1155</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_services_userservice_.userservice.html
+++ b/docs/classes/_services_userservice_.userservice.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L190">services/UserService.ts:190</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L190">services/UserService.ts:190</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L162">services/UserService.ts:162</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L162">services/UserService.ts:162</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -211,7 +211,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L61">services/UserService.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L61">services/UserService.ts:61</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -258,7 +258,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L112">services/UserService.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L112">services/UserService.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -314,7 +314,7 @@ firstUser = <span class="hljs-keyword">await</span> Qminder.users.details(firstU
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L30">services/UserService.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L30">services/UserService.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -355,7 +355,7 @@ firstUser = <span class="hljs-keyword">await</span> Qminder.users.details(firstU
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L140">services/UserService.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L140">services/UserService.ts:140</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -396,7 +396,7 @@ firstUser = <span class="hljs-keyword">await</span> Qminder.users.details(firstU
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L268">services/UserService.ts:268</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L268">services/UserService.ts:268</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -430,7 +430,7 @@ firstUser = <span class="hljs-keyword">await</span> Qminder.users.details(firstU
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L220">services/UserService.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L220">services/UserService.ts:220</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -479,7 +479,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/UserService.ts#L246">services/UserService.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/UserService.ts#L246">services/UserService.ts:246</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_services_webhooksservice_.webhooksservice.html
+++ b/docs/classes/_services_webhooksservice_.webhooksservice.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/WebhooksService.ts#L41">services/WebhooksService.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/WebhooksService.ts#L41">services/WebhooksService.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/WebhooksService.ts#L73">services/WebhooksService.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/WebhooksService.ts#L73">services/WebhooksService.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_api_base_.correctrequestinit.html
+++ b/docs/interfaces/_api_base_.correctrequestinit.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Blob</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L71">api-base.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L71">api-base.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L70">api-base.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L70">api-base.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">credentials<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"omit"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"same-origin"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"include"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L69">api-base.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L69">api-base.ts:69</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">headers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L65">api-base.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L65">api-base.ts:65</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L64">api-base.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L64">api-base.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">mode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"cors"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"same-origin"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"navigate"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"no-cors"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L68">api-base.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L68">api-base.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">referrer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L72">api-base.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L72">api-base.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">referrer<wbr>Policy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L73">api-base.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L73">api-base.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_api_base_.errorresponse.html
+++ b/docs/interfaces/_api_base_.errorresponse.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">developer<wbr>Message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L43">api-base.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L43">api-base.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L42">api-base.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L42">api-base.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L41">api-base.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L41">api-base.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_api_base_.graphqlerror.html
+++ b/docs/interfaces/_api_base_.graphqlerror.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">error<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L18">api-base.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L18">api-base.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">extensions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L22">api-base.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L22">api-base.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">locations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L23">api-base.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L23">api-base.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L17">api-base.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L17">api-base.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L21">api-base.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L21">api-base.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">query<wbr>Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L20">api-base.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L20">api-base.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">validation<wbr>Error<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L19">api-base.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L19">api-base.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_api_base_.graphqlquery.html
+++ b/docs/interfaces/_api_base_.graphqlquery.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">query<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L11">api-base.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L11">api-base.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">variables<span class="tsd-signature-symbol">:</span> <a href="_api_base_.graphqlqueryvariables.html" class="tsd-signature-type">GraphqlQueryVariables</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L12">api-base.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L12">api-base.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_api_base_.graphqlresponse.html
+++ b/docs/interfaces/_api_base_.graphqlresponse.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L37">api-base.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L37">api-base.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<wbr>Present<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L33">api-base.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L33">api-base.ts:33</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">errors<span class="tsd-signature-symbol">:</span> <a href="_api_base_.graphqlerror.html" class="tsd-signature-type">GraphqlError</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L35">api-base.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L35">api-base.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L31">api-base.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L31">api-base.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_api_base_.successresponse.html
+++ b/docs/interfaces/_api_base_.successresponse.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L47">api-base.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L47">api-base.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_location_.selectfieldoption.html
+++ b/docs/interfaces/_model_location_.selectfieldoption.html
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L115">model/Location.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L115">model/Location.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L116">model/Location.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L116">model/Location.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_location_.selectinputfield.html
+++ b/docs/interfaces/_model_location_.selectinputfield.html
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><a href="_model_location_.selectfieldoption.html" class="tsd-signature-type">SelectFieldOption</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L143">model/Location.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L143">model/Location.ts:143</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L142">model/Location.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L142">model/Location.ts:142</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"select"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L141">model/Location.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L141">model/Location.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_location_.specialinputfield.html
+++ b/docs/interfaces/_model_location_.specialinputfield.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"firstName"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"lastName"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"phoneNumber"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"line"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L103">model/Location.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L103">model/Location.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_location_.textinputfield.html
+++ b/docs/interfaces/_model_location_.textinputfield.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L92">model/Location.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L92">model/Location.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"text"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L91">model/Location.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L91">model/Location.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_user_.userrole.html
+++ b/docs/interfaces/_model_user_.userrole.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L26">model/User.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L26">model/User.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L28">model/User.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L28">model/User.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_user_.html#roletype" class="tsd-signature-type">RoleType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L27">model/User.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L27">model/User.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_services_ticketservice_.callnextrequest.html
+++ b/docs/interfaces/_services_ticketservice_.callnextrequest.html
@@ -106,7 +106,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_services_ticketservice_.ticketcallrequest.html">TicketCallRequest</a>.<a href="_services_ticketservice_.ticketcallrequest.html#desk">desk</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L247">services/TicketService.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L247">services/TicketService.ts:247</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">lines<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L251">services/TicketService.ts:251</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L251">services/TicketService.ts:251</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_services_ticketservice_.ticketcallrequest.html">TicketCallRequest</a>.<a href="_services_ticketservice_.ticketcallrequest.html#user">user</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L246">services/TicketService.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L246">services/TicketService.ts:246</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_services_ticketservice_.ticketcallrequest.html
+++ b/docs/interfaces/_services_ticketservice_.ticketcallrequest.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">desk<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L247">services/TicketService.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L247">services/TicketService.ts:247</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L246">services/TicketService.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L246">services/TicketService.ts:246</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_services_ticketservice_.ticketcountcriteria.html
+++ b/docs/interfaces/_services_ticketservice_.ticketcountcriteria.html
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">caller<span class="tsd-signature-symbol">:</span> <a href="../classes/_model_user_.user.html" class="tsd-signature-type">User</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L45">services/TicketService.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L45">services/TicketService.ts:45</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">line<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L25">services/TicketService.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L25">services/TicketService.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L31">services/TicketService.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L31">services/TicketService.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Called<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L73">services/TicketService.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L73">services/TicketService.ts:73</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L59">services/TicketService.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L59">services/TicketService.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">min<wbr>Called<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L66">services/TicketService.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L66">services/TicketService.ts:66</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">min<wbr>Created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L52">services/TicketService.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L52">services/TicketService.ts:52</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -235,7 +235,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_model_ticket_.html#ticketstatus" class="tsd-signature-type">TicketStatus</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L37">services/TicketService.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L37">services/TicketService.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_services_ticketservice_.ticketcreationrequest.html
+++ b/docs/interfaces/_services_ticketservice_.ticketcreationrequest.html
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L232">services/TicketService.ts:232</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L232">services/TicketService.ts:232</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">extra<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L233">services/TicketService.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L233">services/TicketService.ts:233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L229">services/TicketService.ts:229</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L229">services/TicketService.ts:229</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L230">services/TicketService.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L230">services/TicketService.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">phone<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L231">services/TicketService.ts:231</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L231">services/TicketService.ts:231</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L234">services/TicketService.ts:234</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L234">services/TicketService.ts:234</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_services_ticketservice_.ticketcreationresponse.html
+++ b/docs/interfaces/_services_ticketservice_.ticketcreationresponse.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L255">services/TicketService.ts:255</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L255">services/TicketService.ts:255</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_services_ticketservice_.ticketeditingrequest.html
+++ b/docs/interfaces/_services_ticketservice_.ticketeditingrequest.html
@@ -118,7 +118,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_services_ticketservice_.ticketcreationrequest.html">TicketCreationRequest</a>.<a href="_services_ticketservice_.ticketcreationrequest.html#email">email</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L232">services/TicketService.ts:232</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L232">services/TicketService.ts:232</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_services_ticketservice_.ticketcreationrequest.html">TicketCreationRequest</a>.<a href="_services_ticketservice_.ticketcreationrequest.html#extra">extra</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L233">services/TicketService.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L233">services/TicketService.ts:233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_services_ticketservice_.ticketcreationrequest.html">TicketCreationRequest</a>.<a href="_services_ticketservice_.ticketcreationrequest.html#firstname">firstName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L229">services/TicketService.ts:229</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L229">services/TicketService.ts:229</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_services_ticketservice_.ticketcreationrequest.html">TicketCreationRequest</a>.<a href="_services_ticketservice_.ticketcreationrequest.html#lastname">lastName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L230">services/TicketService.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L230">services/TicketService.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">line<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L241">services/TicketService.ts:241</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L241">services/TicketService.ts:241</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_services_ticketservice_.ticketcreationrequest.html">TicketCreationRequest</a>.<a href="_services_ticketservice_.ticketcreationrequest.html#phonenumber">phoneNumber</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L231">services/TicketService.ts:231</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L231">services/TicketService.ts:231</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_services_ticketservice_.ticketcreationrequest.html">TicketCreationRequest</a>.<a href="_services_ticketservice_.ticketcreationrequest.html#source">source</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L234">services/TicketService.ts:234</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L234">services/TicketService.ts:234</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L242">services/TicketService.ts:242</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L242">services/TicketService.ts:242</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_services_ticketservice_.ticketsearchcriteria.html
+++ b/docs/interfaces/_services_ticketservice_.ticketsearchcriteria.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">caller<span class="tsd-signature-symbol">:</span> <a href="../classes/_model_user_.user.html" class="tsd-signature-type">User</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L112">services/TicketService.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L112">services/TicketService.ts:112</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L147">services/TicketService.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L147">services/TicketService.ts:147</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">line<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L92">services/TicketService.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L92">services/TicketService.ts:92</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L98">services/TicketService.ts:98</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L98">services/TicketService.ts:98</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Called<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L140">services/TicketService.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L140">services/TicketService.ts:140</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -204,7 +204,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L126">services/TicketService.ts:126</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L126">services/TicketService.ts:126</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">min<wbr>Called<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L133">services/TicketService.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L133">services/TicketService.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">min<wbr>Created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L119">services/TicketService.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L119">services/TicketService.ts:119</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -255,7 +255,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L160">services/TicketService.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L160">services/TicketService.ts:160</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 					<div class="tsd-signature tsd-kind-icon">response<wbr>Scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"MESSAGES"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"INTERACTIONS"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"MESSAGES"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"INTERACTIONS"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L182">services/TicketService.ts:182</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L182">services/TicketService.ts:182</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_model_ticket_.html#ticketstatus" class="tsd-signature-type">TicketStatus</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L104">services/TicketService.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L104">services/TicketService.ts:104</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_api_base_.html
+++ b/docs/modules/_api_base_.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Api<wbr>Response<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_api_base_.errorresponse.html" class="tsd-signature-type">ErrorResponse</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_api_base_.successresponse.html" class="tsd-signature-type">SuccessResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L50">api-base.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L50">api-base.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">HTTPMethod<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"GET"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"POST"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"PUT"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"PATCH"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"OPTIONS"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"HEAD"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"DELETE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"CONNECT"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/api-base.ts#L4">api-base.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/api-base.ts#L4">api-base.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_lib_websocket_web_.html
+++ b/docs/modules/_lib_websocket_web_.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Message<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/lib/websocket-web.ts#L2">lib/websocket-web.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/lib/websocket-web.ts#L2">lib/websocket-web.ts:2</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_model_location_.html
+++ b/docs/modules/_model_location_.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">Input<wbr>Field<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_model_location_.specialinputfield.html" class="tsd-signature-type">SpecialInputField</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_model_location_.textinputfield.html" class="tsd-signature-type">TextInputField</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_model_location_.selectinputfield.html" class="tsd-signature-type">SelectInputField</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Location.ts#L76">model/Location.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Location.ts#L76">model/Location.ts:76</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_model_ticket_.html
+++ b/docs/modules/_model_ticket_.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ticket<wbr>Audit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L315">model/Ticket.ts:315</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L312">model/Ticket.ts:312</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ticket<wbr>Audit<wbr>Change<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L321">model/Ticket.ts:321</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L318">model/Ticket.ts:318</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ticket<wbr>Extra<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L217">model/Ticket.ts:217</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L214">model/Ticket.ts:214</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ticket<wbr>Interaction<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L236">model/Ticket.ts:236</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L233">model/Ticket.ts:233</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -237,7 +237,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ticket<wbr>Label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L252">model/Ticket.ts:252</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L249">model/Ticket.ts:249</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -267,7 +267,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ticket<wbr>Message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L305">model/Ticket.ts:305</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L302">model/Ticket.ts:302</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -339,7 +339,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ticket<wbr>Status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"NEW"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"CALLED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"CANCELLED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"CANCELLED_BY_CLERK"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"NOSHOW"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"SERVED"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/Ticket.ts#L339">model/Ticket.ts:339</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/Ticket.ts#L336">model/Ticket.ts:336</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_model_user_.html
+++ b/docs/modules/_model_user_.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L6">model/User.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L6">model/User.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">Role<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"CLERK"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"MANAGER"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"ADMIN"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"OWNER"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/model/User.ts#L19">model/User.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/model/User.ts#L19">model/User.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_qminder_api_.html
+++ b/docs/modules/_qminder_api_.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/qminder-api.ts#L78">qminder-api.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/qminder-api.ts#L78">qminder-api.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">graphql<span class="tsd-signature-symbol">:</span> <a href="../classes/_services_graphqlservice_.graphqlservice.html#query" class="tsd-signature-type">query</a><span class="tsd-signature-symbol"> =&nbsp;GraphQLService.query</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/qminder-api.ts#L82">qminder-api.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/qminder-api.ts#L82">qminder-api.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/qminder-api.ts#L59">qminder-api.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/qminder-api.ts#L59">qminder-api.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_services_eventsservice_.html
+++ b/docs/modules/_services_eventsservice_.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Event<wbr>Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L13">services/EventsService.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L13">services/EventsService.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">Event<wbr>Filter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L16">services/EventsService.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L16">services/EventsService.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">Event<wbr>Subscription<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L19">services/EventsService.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L19">services/EventsService.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">Event<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"TICKET_CREATED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"TICKET_CALLED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"TICKET_RECALLED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"TICKET_CANCELLED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"TICKET_SERVED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"TICKET_CHANGED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"OVERVIEW_MONITOR_CHANGE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"SIGN_IN_CHANGE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"LINES_CHANGED"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"LOCATION_CHANGE"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/EventsService.ts#L8">services/EventsService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/EventsService.ts#L8">services/EventsService.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_services_ticketservice_.html
+++ b/docs/modules/_services_ticketservice_.html
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">Desired<wbr>Queue<wbr>Position<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"FIRST"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"MIDDLE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"LAST"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L191">services/TicketService.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L191">services/TicketService.ts:191</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">ERROR_<wbr>NO_<wbr>LINE_<wbr>ID<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;Line ID missing from arguments.&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L196">services/TicketService.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L196">services/TicketService.ts:196</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">ERROR_<wbr>NO_<wbr>QUEUE_<wbr>POSITION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;Queue position missing from arguments.&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L221">services/TicketService.ts:221</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L221">services/TicketService.ts:221</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">ERROR_<wbr>NO_<wbr>TICKET_<wbr>ID<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;Ticket ID missing from arguments.&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/5b39121/src/services/TicketService.ts#L206">services/TicketService.ts:206</a></li>
+							<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/12d65d8/src/services/TicketService.ts#L206">services/TicketService.ts:206</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system",
   "directories": {
     "test": "test"

--- a/src/model/Ticket.ts
+++ b/src/model/Ticket.ts
@@ -19,7 +19,7 @@ class Ticket {
   /**
    * This ticket's unique ID. For example, 14995020
    */
-  id: number;
+  id: number | string;
 
   /**
    * This ticket's unique number. For example, 105.
@@ -162,13 +162,10 @@ class Ticket {
   messages?: TicketMessage[];
 
 
-  constructor(properties: number | Ticket) {
-    if (typeof properties === 'number') {
+  constructor(properties: number | string | Ticket) {
+    if (typeof properties !== 'object') {
       this.id = properties;
     } else {
-      if (typeof properties.id === 'string') {
-        properties.id = parseInt(properties.id, 10);
-      }
       Object.assign(this, properties);
     }
   }

--- a/test/web/TicketService.test.js
+++ b/test/web/TicketService.test.js
@@ -541,7 +541,6 @@ describe("TicketService", function() {
         expect(response instanceof Qminder.Ticket).toBeTruthy();
         expect(response.line).toBe(11111);
         expect(response.id).toBe(12345);
-        expect(typeof response.id).toBe("number");
         done();
       });
     });
@@ -628,7 +627,6 @@ describe("TicketService", function() {
     it('resolves to a Ticket object', function(done) {
       Qminder.tickets.details(12345).then(response => {
         expect(response instanceof Qminder.Ticket).toBeTruthy();
-        expect(typeof response.id).toBe("number");
         expect(response).toEqual(jasmine.objectContaining(detailsResponseBody));
         done();
       });


### PR DESCRIPTION
Ticket IDs are strings all over the application. Converting them to ints in some methods causes issues (threequals checks will fail).

This PR reverts that change and allows ticket IDs to be both strings and ints. 

Tests will follow with a future release.