### PR TITLE
Added .idea to .gitignore and made GraphQL subscription error handling safer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 yarn-error.log
 # IDEA GraphQL plugin config
 graphql.config.json
+.idea

--- a/src/services/GraphQLService.ts
+++ b/src/services/GraphQLService.ts
@@ -6,6 +6,7 @@ interface OperationMessage {
     id?: string;
     type: MessageType;
     payload?: any;
+    errors?: any[];
 }
 
 class Subscription {
@@ -240,7 +241,11 @@ class GraphQLService {
                         break;
 
                     default:
-                        this.subscriptionObserverMap[message.id].error(message.payload.data);
+                        if(message.payload && message.payload.data) {
+                            this.subscriptionObserverMap[message.id].error(message.payload.data);
+                        } else if(message.errors && message.errors.length > 0) {
+                            this.subscriptionObserverMap[message.id].error(message.errors);
+                        }
                 }
             }
 


### PR DESCRIPTION
Note: currently backend doesn't send subscription ID with errors in GraphQL subscriptions, this will have to wait on that.