### PR TITLE
RxJS is now a peer dependency of javascript-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-sinon": "^1.0.5",
     "mocha": "^4.0.1",
+    "rxjs": "^6.5.3",
     "sinon": "^3.2.0",
     "ts-loader": "^4.4.0",
     "typedoc": "^0.11.1",
@@ -105,7 +106,9 @@
     "es6-promise": "^4.1.1",
     "isomorphic-fetch": "^2.2.1",
     "querystring": "^0.2.0",
-    "rxjs": "6.5.3",
     "ws": "^3.2.0"
+  },
+  "peerDependencies": {
+    "rxjs": "^6.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "2.2.21",
+  "version": "2.2.22",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system.",
   "directories": {
     "test": "test"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4302,16 +4302,16 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@6.5.3:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
-  integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
-  dependencies:
-    tslib "^1.9.0"
-
 rxjs@^6.1.0:
   version "6.3.2"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz#6a688b16c4e6e980e62ea805ec30648e1c60907f"
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.3:
+  version "6.5.4"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
+  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This PR makes it so that RxJS is a peer dependency of `qminder-api`. This change ensures that only one copy of RxJS is installed if a consumer of the JS API uses RxJS as well. 

Practically nothing changes, since RxJS is required to use GraphQL subscriptions - and consumers of that API already install it.

It should be safe to upgrade projects to use this, even those that don't use RxJS. However, we should still test during the upgrade - if everything works as expected.
