### PR TITLE
Simplify Ticket types and accept User for ticket editing, fixes #255

### DIFF
--- a/test/web/TicketService.test.js
+++ b/test/web/TicketService.test.js
@@ -661,7 +661,7 @@ describe("TicketService", function() {
       expect(() => Qminder.tickets.details(undefined)).toThrow();
     });
     it('throws when ticket is invalid', function() {
-      expect(() => Qminder.tickets.details("wheeee")).toThrow();
+      expect(() => Qminder.tickets.details(function() {})).toThrow();
     });
     it('throws when ticket is a Ticket object but id is undefined', function() {
       expect(() => Qminder.tickets.details(new Qminder.Ticket({}))).toThrow();
@@ -768,6 +768,13 @@ describe("TicketService", function() {
       Qminder.tickets.edit(12345, { email: null });
       expect(this.requestStub.calledWith('tickets/12345/edit',
         sinon.match({ email: null }))).toBeTruthy();
+    });
+
+    it('sends the User ID if provided', function() {
+      Qminder.tickets.edit(12345, { user: 14141, email: null });
+
+      expect(this.requestStub.calledWith('tickets/12345/edit',
+        sinon.match({ email: null, user: 14141 }))).toBeTruthy();
     });
 
     it('Sends the extras as a JSON array', function() {


### PR DESCRIPTION
This PR does three things:

- Accepts user parameter for ticket editing and sends it onwards to the HTTP request
- Replaces ticket types with specific TicketCreateParameters / TicketEditParameters
- Accepts string ID for ticket

The unit tests reflect that and have been updated with the User check as well.

Fixes #255 
Fixes #244 
Fixes #193 
Fixes #150