### PR TITLE
refactor: remove `getInputFields` method

### DIFF
--- a/docs/classes/_services_locationservice_.locationservice.html
+++ b/docs/classes/_services_locationservice_.locationservice.html
@@ -191,48 +191,6 @@ Qminder.setKey(<span class="hljs-string">'API_KEY_HERE'</span>);
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-static">
-					<a name="getinputfields" class="tsd-anchor"></a>
-					<h3><span class="tsd-flag ts-flagStatic">Static</span> get<wbr>Input<wbr>Fields</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">get<wbr>Input<wbr>Fields<span class="tsd-signature-symbol">(</span>location<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><a href="_model_location_.location.html" class="tsd-signature-type">Location</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_model_location_.html#inputfield" class="tsd-signature-type">InputField</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
-					</ul>
-					<ul class="tsd-descriptions">
-						<li class="tsd-description">
-							<aside class="tsd-sources">
-								<ul>
-									<li>Defined in <a href="https://github.com/Qminder/javascript-api/blob/ae5ddbf/src/services/LocationService.ts#L115">services/LocationService.ts:115</a></li>
-								</ul>
-							</aside>
-							<div class="tsd-comment tsd-typography">
-								<div class="lead">
-									<p>Get the input fields in a particular location.
-										This returns a list of the configured input fields that clerks can enter on the Qminder
-									Dashboard Service View.</p>
-								</div>
-								<p>Calls the following HTTP API: <code>GET /locations/&lt;ID&gt;/input-fields</code></p>
-								<p>For example:</p>
-								<pre><code class="lang-javascript"><span class="hljs-comment">// Get the input fields for a location that has only Line, First Name &amp; Last Name enabled</span>
-<span class="hljs-keyword">const</span> inputFields = <span class="hljs-keyword">await</span> Qminder.locations.getInputFields(<span class="hljs-number">1234</span>);
-<span class="hljs-built_in">console</span>.log(inputFields);
-<span class="hljs-comment">// =&gt; [ { type: 'firstName' }, { type: 'lastName' }, { type: 'line' } ]</span>
-</code></pre>
-							</div>
-							<h4 class="tsd-parameters-title">Parameters</h4>
-							<ul class="tsd-parameters">
-								<li>
-									<h5>location: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><a href="_model_location_.location.html" class="tsd-signature-type">Location</a></h5>
-									<div class="tsd-comment tsd-typography">
-										<p>the location to query, either as an ID or a Qminder Location object</p>
-									</div>
-								</li>
-							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_model_location_.html#inputfield" class="tsd-signature-type">InputField</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
-							<p>a Promise that resolves to an array of input fields, or rejects if something went
-							wrong.</p>
-						</li>
-					</ul>
-				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-static">
 					<a name="list" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> list</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-static">

--- a/src/services/LocationService.ts
+++ b/src/services/LocationService.ts
@@ -92,38 +92,4 @@ export default class LocationService {
       return response.desks.map(each => new Desk(each));
     });
   }
-
-  /**
-   * Get the input fields in a particular location.
-   * This returns a list of the configured input fields that clerks can enter on the Qminder
-   * Dashboard Service View.
-   *
-   * Calls the following HTTP API: `GET /locations/<ID>/input-fields`
-   *
-   * For example:
-   *
-   * ```javascript
-   * // Get the input fields for a location that has only Line, First Name & Last Name enabled
-   * const inputFields = await Qminder.locations.getInputFields(1234);
-   * console.log(inputFields);
-   * // => [ { type: 'firstName' }, { type: 'lastName' }, { type: 'line' } ]
-   * ```
-   * @param location the location to query, either as an ID or a Qminder Location object
-   * @returns a Promise that resolves to an array of input fields, or rejects if something went
-   * wrong.
-   */
-  static getInputFields(location: (Location | number)): Promise<InputField[]> {
-    let locationId: any = null;
-    // Get the location's ID
-    if (location instanceof Location) {
-      locationId = location.id;
-    } else {
-      locationId = location;
-    }
-    if (!locationId || typeof locationId !== 'number') {
-      throw new Error(ERROR_NO_LOCATION_ID);
-    }
-    return ApiBase.request(`locations/${locationId}/input-fields`)
-                  .then((response: { fields: InputField[] }) => response.fields);
-  }
 };

--- a/test/unit/LocationService.test.ts
+++ b/test/unit/LocationService.test.ts
@@ -152,46 +152,6 @@ describe("Qminder.locations", function() {
     });
   });
 
-  describe("getInputFields()", function() {
-    const fields = [
-      { type: 'firstName' },
-      { type: 'lastName' },
-    ];
-    beforeEach(function() {
-      requestStub.withArgs(`locations/${LOCATION_ID}/input-fields`).resolves({ fields });
-    });
-    it('throws with undefined location ID', function() {
-      expect(() => (Qminder.locations.getInputFields as any)()).toThrow();
-    });
-    it('throws with an object that doesn\'t fit', function() {
-      expect(() => (Qminder.locations.getInputFields as any)({ statusCode: 200 })).toThrow();
-    });
-    it('does not throw with numeric location ID', function() {
-      expect(() => Qminder.locations.getInputFields(LOCATION_ID)).not.toThrow();
-    });
-    it('does not throw with Qminder.Location', function() {
-      expect(() => Qminder.locations.getInputFields(new Qminder.Location(LOCATION_ID))).not.toThrow();
-    });
-    it('calls the right URL with numeric location ID', function(done) {
-      Qminder.locations.getInputFields(LOCATION_ID).then(() => {
-        expect(requestStub.calledWith(`locations/${LOCATION_ID}/input-fields`)).toBeTruthy();
-        done();
-      }, (err) => {
-        expect(err).toBeUndefined();
-        done();
-      });
-    });
-    it('gets the input fields from the response object', function(done) {
-      Qminder.locations.getInputFields(LOCATION_ID).then((response) => {
-        expect(response).toEqual(fields);
-        done();
-      }, (err) => {
-        expect(err).toBeUndefined();
-        done();
-      });
-    });
-  });
-
   afterEach(function() {
     requestStub.restore();
   })


### PR DESCRIPTION
## Description of the change

This PR removes a method for fetching location input fields since it is not a part of the public API anymore.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

