### PR TITLE
Support tagged GraphQL strings (and other pre-parsed GraphQL) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "ws": "^7.4.3"
   },
   "peerDependencies": {
-    "rxjs": "6.6.3"
+    "rxjs": "6.6.3",
+    "graphql-tag": ">= 2.12.5",
+    "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system.",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "sinon": "^9.2.4",
     "ts-jest": "^26.5.1",
     "typedoc": "^0.11.1",
-    "typescript": "4.1.4"
+    "typescript": "4.1.4",
+    "graphql": ">= 15.5.1",
+    "graphql-tag": ">= 2.12.5"
   },
   "dependencies": {
     "@types/isomorphic-fetch": "^0.0.34",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "ws": "^7.4.3"
   },
   "peerDependencies": {
-    "rxjs": "6.6.3",
+    "graphql": ">= 15.5.1",
     "graphql-tag": ">= 2.12.5",
-    "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+    "rxjs": "6.6.3"
   },
   "publishConfig": {
     "access": "public",

--- a/test/unit/GraphQLService.test.ts
+++ b/test/unit/GraphQLService.test.ts
@@ -73,9 +73,30 @@ describe('GraphQLService', function() {
       }`) as any)).not.toThrow();
 
       expect(requestStub.callCount).toBe(1);
-      expect(requestStub.calledWith({
-        query: '{ me { id }\n}'
-      })).toBeTruthy();
+      expect(requestStub.firstCall.args[0]).toEqual({
+        query: '{ me { id }\n}',
+      });
+    });
+    it('testing a longer query', () => {
+      expect(() => (Qminder.graphql.query(gql`query MyIdQuery($id: ID!) {
+        location(id: $id) {
+          id
+          name
+          timezone 
+          lines {
+            ...MyFrag
+          }
+        }
+      }
+      fragment MyFrag on Line {
+        id
+        name 
+      }`) as any)).not.toThrow();
+
+      expect(requestStub.callCount).toBe(1);
+      expect(requestStub.firstCall.args[0]).toEqual({
+        query: 'query MyIdQuery($id: ID!) { location(id: $id) { id name timezone lines { ...MyFrag } }\n} fragment MyFrag on Line { id name\n}',
+      });
     });
   });
 

--- a/test/unit/GraphQLService.test.ts
+++ b/test/unit/GraphQLService.test.ts
@@ -1,5 +1,6 @@
 import * as Qminder from '../../src/qminder-api';
 import * as sinon from 'sinon';
+import { gql } from 'graphql-tag';
 
 describe('GraphQLService', function() {
   const ME_ID_REQUEST = '{ me { id } }';
@@ -58,6 +59,24 @@ describe('GraphQLService', function() {
       expect(requestStub.callCount).toBe(0);
     });
 
+  });
+
+  describe('graphql tag support', () => {
+    beforeEach(function() {
+      requestStub.onFirstCall().resolves(ME_ID_SUCCESS_RESPONSE);
+    });
+    it('Qminder.graphql.query works correctly when passed a gql`` tagged query', () => {
+      expect(() => (Qminder.graphql.query(gql`{
+        me {
+          id
+        }
+      }`) as any)).not.toThrow();
+
+      expect(requestStub.callCount).toBe(1);
+      expect(requestStub.calledWith({
+        query: '{ me { id }\n}'
+      })).toBeTruthy();
+    });
   });
 
   afterEach(function() {

--- a/test/unit/GraphQLService.test.ts
+++ b/test/unit/GraphQLService.test.ts
@@ -77,7 +77,7 @@ describe('GraphQLService', function() {
         query: '{ me { id }\n}',
       });
     });
-    it('testing a longer query', () => {
+    it('Qminder.graphql.query works correctly when passed a long query with variables and fragments', () => {
       expect(() => (Qminder.graphql.query(gql`query MyIdQuery($id: ID!) {
         location(id: $id) {
           id

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,6 +2193,18 @@ graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+"graphql-tag@>= 2.12.5":
+  version "2.12.5"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.5.tgz#5cff974a67b417747d05c8d9f5f3cb4495d0db8f"
+  integrity sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==
+  dependencies:
+    tslib "^2.1.0"
+
+"graphql@>= 15.5.1":
+  version "15.5.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.1.tgz#f2f84415d8985e7b84731e7f3536f8bb9d383aad"
+  integrity sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -4204,6 +4216,11 @@ ts-jest@^26.5.1:
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tslib@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
## Description of the change

This PR adds support for tagged GraphQL strings (popularized by frameworks like Apollo and Relay). It should help with syntax highlighting and validation during compilation / early runtime.

**Before:**

```typescript
// Supported as-is
Qminder.graphql.query("{ me { id } }")
// Breaking change highlighted below ⚠️ 
Qminder.graphql.query("changedTickets(...) { id }")
```

**After:**


```typescript
// this version will syntax-highlight, and do schema completion in most IDEs
Qminder.graphql.query(gql`{ me { id } }`)
Qminder.graphql.query(gql`subscription { changedTickets(...) { id } }`)
```

⚠️ As a related change, `subscription {` and `}` are no longer automatically added to .subscribe() calls for GraphQL subscriptions.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

