### PR TITLE
feat(errors): GraphQL API errors are exposed as rejected promises

### DIFF
--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,0 +1,9 @@
+import { GraphQLError } from 'graphql';
+
+export class GraphQLApiError extends Error {
+  message: string;
+  constructor(errors: GraphQLError[]) {
+    super();
+    this.message = errors.map((error) => error.message).join('\n');
+  }
+}


### PR DESCRIPTION
## Description of the change

This PR changes the Qminder.graphql.query signature to reject the promise when the GraphQL API returns with errors.

A new error type was introduced, `GraphQLApiError`, which stores the message from the backend as the error's message.

This is a breaking change.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

