### PR TITLE
Remove subscription {} from automatically being added

### DIFF
--- a/src/services/GraphQLService.ts
+++ b/src/services/GraphQLService.ts
@@ -288,7 +288,7 @@ export class GraphQLService {
             this.setConnectionStatus(ConnectionStatus.CONNECTED);
             this.subscriptions.forEach((subscription) => {
               const payload = {
-                query: `subscription { ${subscription.query} }`,
+                query: subscription.query,
               };
               const msg = JSON.stringify({
                 id: subscription.id,


### PR DESCRIPTION
## Description of the change

This PR makes sure that `subscription {}` is not automatically added around subscriptions. It causes issues during reconnects or very early subscriptions.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Related issues

Fixes #320 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

