### PR TITLE
feat: handle new error response type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system.",
   "scripts": {
     "test": "jest",

--- a/src/api-base.ts
+++ b/src/api-base.ts
@@ -60,7 +60,10 @@ export interface SuccessResponse {
   statusCode: number;
 }
 
-type ApiResponse<T = {}> = LegacyErrorResponse | ClientErrorResponse | (SuccessResponse & T);
+type ApiResponse<T = {}> =
+  | LegacyErrorResponse
+  | ClientErrorResponse
+  | (SuccessResponse & T);
 
 /**
  * Returns true if an ApiResponse is an Error response, usable as a type guard.
@@ -68,10 +71,14 @@ type ApiResponse<T = {}> = LegacyErrorResponse | ClientErrorResponse | (SuccessR
  * @returns true if the ApiResponse is an LegacyErrorResponse, false if it is a SuccessResponse
  * @hidden
  */
-function responseIsLegacyError(response: ApiResponse): response is LegacyErrorResponse {
-  return response.statusCode
-      && Math.floor(response.statusCode / 100) !== 2
-      && !Object.prototype.hasOwnProperty.call(response, 'error');
+function responseIsLegacyError(
+  response: ApiResponse,
+): response is LegacyErrorResponse {
+  return (
+    response.statusCode &&
+    Math.floor(response.statusCode / 100) !== 2 &&
+    !Object.prototype.hasOwnProperty.call(response, 'error')
+  );
 }
 
 /**
@@ -80,10 +87,14 @@ function responseIsLegacyError(response: ApiResponse): response is LegacyErrorRe
  * @returns true if the ApiResponse is an ClientErrorResponse, false if it is a SuccessResponse
  * @hidden
  */
-function responseIsClientError(response: ApiResponse): response is ClientErrorResponse {
-  return response.statusCode
-      && Math.floor(response.statusCode / 100) == 4
-      && Object.prototype.hasOwnProperty.call(response, 'error');
+function responseIsClientError(
+  response: ApiResponse,
+): response is ClientErrorResponse {
+  return (
+    response.statusCode &&
+    Math.floor(response.statusCode / 100) == 4 &&
+    Object.prototype.hasOwnProperty.call(response, 'error')
+  );
 }
 
 // NOTE: this is defined because the RequestInit type has issues
@@ -200,20 +211,20 @@ class ApiBase {
     }
 
     return this.fetch(`https://${this.apiServer}/v1/${url}`, init)
-        .then((response: Response) => response.json())
-        .then((responseJson: ApiResponse) => {
-          if (responseIsLegacyError(responseJson)) {
-            throw new Error(
-                responseJson.developerMessage || responseJson.message,
-            );
-          }
-          if (responseIsClientError(responseJson)) {
-            const key = Object.keys(responseJson.error)[0];
-            const message = Object.values(responseJson.error)[0];
-            throw new ClientError(key, message);
-          }
-          return responseJson;
-        });
+      .then((response: Response) => response.json())
+      .then((responseJson: ApiResponse) => {
+        if (responseIsLegacyError(responseJson)) {
+          throw new Error(
+            responseJson.developerMessage || responseJson.message,
+          );
+        }
+        if (responseIsClientError(responseJson)) {
+          const key = Object.keys(responseJson.error)[0];
+          const message = Object.values(responseJson.error)[0];
+          throw new ClientError(key, message);
+        }
+        return responseJson;
+      });
   }
 
   /**

--- a/src/api-base.ts
+++ b/src/api-base.ts
@@ -92,7 +92,7 @@ function responseIsClientError(
 ): response is ClientErrorResponse {
   return (
     response.statusCode &&
-    Math.floor(response.statusCode / 100) == 4 &&
+    Math.floor(response.statusCode / 100) === 4 &&
     Object.prototype.hasOwnProperty.call(response, 'error')
   );
 }

--- a/src/model/ClientError.ts
+++ b/src/model/ClientError.ts
@@ -1,9 +1,8 @@
 export class ClientError extends Error {
+  private field: string;
 
-    private field: string;
-
-    constructor(field: string, message: string) {
-        super(message);
-        this.field = field;
-    }
+  constructor(field: string, message: string) {
+    super(message);
+    this.field = field;
+  }
 }

--- a/src/model/ClientError.ts
+++ b/src/model/ClientError.ts
@@ -1,0 +1,9 @@
+export class ClientError extends Error {
+
+    private field: string;
+
+    constructor(field: string, message: string) {
+        super(message);
+        this.field = field;
+    }
+}

--- a/src/qminder-api.ts
+++ b/src/qminder-api.ts
@@ -6,6 +6,7 @@ import Location from './model/Location';
 import Ticket from './model/Ticket';
 import User from './model/User';
 import Webhook from './model/Webhook';
+import { ClientError } from './model/ClientError';
 
 // Import services
 import ApiBase from './api-base';
@@ -18,7 +19,17 @@ import WebhooksService from './services/WebhooksService';
 import GraphQLService, { ConnectionStatus } from './services/GraphQLService';
 
 // Export all data structures
-export { ApiBase, Desk, Device, Line, Location, Ticket, User, Webhook };
+export {
+  ApiBase,
+  Desk,
+  Device,
+  Line,
+  Location,
+  Ticket,
+  User,
+  Webhook,
+  ClientError,
+};
 
 // Export misc structures
 export { ConnectionStatus };

--- a/test/unit/ApiBase.test.ts
+++ b/test/unit/ApiBase.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 import * as Qminder from '../../src/qminder-api';
 import { GraphQLApiError } from '../../src/util/errors';
-import {ClientError} from "../../build/model/ClientError";
+import { ClientError } from '../../src/model/ClientError';
 
 /**
  * A function that generates an object with the following keys:

--- a/test/unit/ApiBase.test.ts
+++ b/test/unit/ApiBase.test.ts
@@ -306,16 +306,13 @@ describe('ApiBase', function () {
 
       fetchSpy.onCall(0).resolves(new MockResponse(response));
 
-      Qminder.ApiBase.request('TEST')
-          .then(
-              () => done(new Error('Should have errored')),
-              (error: GraphQLApiError) => {
-                expect(error).toEqual(
-                    new Error('Oh, snap!'),
-                );
-                done();
-              },
-          );
+      Qminder.ApiBase.request('TEST').then(
+        () => done(new Error('Should have errored')),
+        (error: GraphQLApiError) => {
+          expect(error).toEqual(new Error('Oh, snap!'));
+          done();
+        },
+      );
     });
 
     it('handles legacy error response (developerMessage)', (done) => {
@@ -328,16 +325,13 @@ describe('ApiBase', function () {
 
       fetchSpy.onCall(0).resolves(new MockResponse(response));
 
-      Qminder.ApiBase.request('TEST')
-          .then(
-              () => done(new Error('Should have errored')),
-              (error: GraphQLApiError) => {
-                expect(error).toEqual(
-                    new Error('Oh, snap!'),
-                );
-                done();
-              },
-          );
+      Qminder.ApiBase.request('TEST').then(
+        () => done(new Error('Should have errored')),
+        (error: GraphQLApiError) => {
+          expect(error).toEqual(new Error('Oh, snap!'));
+          done();
+        },
+      );
     });
 
     it('handles client error', (done) => {
@@ -345,21 +339,20 @@ describe('ApiBase', function () {
 
       const response: any = {
         statusCode: 409,
-        error: {'email': 'Email already in use'},
+        error: { email: 'Email already in use' },
       };
 
       fetchSpy.onCall(0).resolves(new MockResponse(response));
 
-      Qminder.ApiBase.request('TEST')
-          .then(
-              () => done(new Error('Should have errored')),
-              (error: GraphQLApiError) => {
-                expect(error).toEqual(
-                    new ClientError('email', 'Email already in use'),
-                );
-                done();
-              },
+      Qminder.ApiBase.request('TEST').then(
+        () => done(new Error('Should have errored')),
+        (error: GraphQLApiError) => {
+          expect(error).toEqual(
+            new ClientError('email', 'Email already in use'),
           );
+          done();
+        },
+      );
     });
   });
 

--- a/test/unit/ApiBase.test.ts
+++ b/test/unit/ApiBase.test.ts
@@ -1,6 +1,7 @@
 import * as sinon from 'sinon';
 import * as Qminder from '../../src/qminder-api';
 import { GraphQLApiError } from '../../src/util/errors';
+import {ClientError} from "../../build/model/ClientError";
 
 /**
  * A function that generates an object with the following keys:
@@ -293,6 +294,72 @@ describe('ApiBase', function () {
       const url = 'https://api.qminder.com/v1/TEST';
 
       expect(fetchSpy.calledWithExactly(url, requestMatcher)).toBe(true);
+    });
+
+    it('handles legacy error response (message)', (done) => {
+      Qminder.setKey(API_KEY);
+
+      const response: any = {
+        statusCode: 409,
+        message: 'Oh, snap!',
+      };
+
+      fetchSpy.onCall(0).resolves(new MockResponse(response));
+
+      Qminder.ApiBase.request('TEST')
+          .then(
+              () => done(new Error('Should have errored')),
+              (error: GraphQLApiError) => {
+                expect(error).toEqual(
+                    new Error('Oh, snap!'),
+                );
+                done();
+              },
+          );
+    });
+
+    it('handles legacy error response (developerMessage)', (done) => {
+      Qminder.setKey(API_KEY);
+
+      const response: any = {
+        statusCode: 409,
+        developerMessage: 'Oh, snap!',
+      };
+
+      fetchSpy.onCall(0).resolves(new MockResponse(response));
+
+      Qminder.ApiBase.request('TEST')
+          .then(
+              () => done(new Error('Should have errored')),
+              (error: GraphQLApiError) => {
+                expect(error).toEqual(
+                    new Error('Oh, snap!'),
+                );
+                done();
+              },
+          );
+    });
+
+    it('handles client error', (done) => {
+      Qminder.setKey(API_KEY);
+
+      const response: any = {
+        statusCode: 409,
+        error: {'email': 'Email already in use'},
+      };
+
+      fetchSpy.onCall(0).resolves(new MockResponse(response));
+
+      Qminder.ApiBase.request('TEST')
+          .then(
+              () => done(new Error('Should have errored')),
+              (error: GraphQLApiError) => {
+                expect(error).toEqual(
+                    new ClientError('email', 'Email already in use'),
+                );
+                done();
+              },
+          );
     });
   });
 


### PR DESCRIPTION
## Description of the change

We have new standardised error response type.

### Example
```json
{"error":{"email":"Email address is in use"},"statusCode":409}
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

