### PR TITLE
fix: ticket creation will not send null as a last name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system.",
   "scripts": {
     "test": "jest",

--- a/src/services/TicketService.ts
+++ b/src/services/TicketService.ts
@@ -500,6 +500,9 @@ export default class TicketService {
     const lineId = extractId(line);
 
     const converted: any = { ...ticket };
+    if (converted.lastName === null) {
+      delete converted.lastName;
+    }
     if (converted.extra) {
       converted.extra = JSON.stringify(converted.extra);
     }

--- a/test/unit/TicketService.test.ts
+++ b/test/unit/TicketService.test.ts
@@ -803,7 +803,10 @@ describe('TicketService', function () {
       Qminder.tickets.create(1, ticket);
       Qminder.tickets.create(1, ticket);
       expect(
-          requestStub.calledWith('lines/1/ticket', sinon.match.has('lastName', 'Smith')),
+        requestStub.calledWith(
+          'lines/1/ticket',
+          sinon.match.has('lastName', 'Smith'),
+        ),
       ).toBeTruthy();
     });
     it('does not send last name if it is null', function () {
@@ -813,9 +816,12 @@ describe('TicketService', function () {
       };
       Qminder.tickets.create(1, ticket);
       expect(
-          requestStub.calledWith('lines/1/ticket', sinon.match((value) => {
+        requestStub.calledWith(
+          'lines/1/ticket',
+          sinon.match((value) => {
             return value.lastName === undefined;
-          })),
+          }),
+        ),
       ).toBeTruthy();
     });
     it('sends email address if it is defined', function () {

--- a/test/unit/TicketService.test.ts
+++ b/test/unit/TicketService.test.ts
@@ -795,6 +795,29 @@ describe('TicketService', function () {
         requestStub.calledWith('lines/1/ticket', sinon.match({})),
       ).toBeTruthy();
     });
+    it('sends last name if it is not null', function () {
+      const ticket: any = {
+        firstName: 'Jane',
+        lastName: 'Smith',
+      };
+      Qminder.tickets.create(1, ticket);
+      Qminder.tickets.create(1, ticket);
+      expect(
+          requestStub.calledWith('lines/1/ticket', sinon.match.has('lastName', 'Smith')),
+      ).toBeTruthy();
+    });
+    it('does not send last name if it is null', function () {
+      const ticket: any = {
+        firstName: 'Jane',
+        lastName: null,
+      };
+      Qminder.tickets.create(1, ticket);
+      expect(
+          requestStub.calledWith('lines/1/ticket', sinon.match((value) => {
+            return value.lastName === undefined;
+          })),
+      ).toBeTruthy();
+    });
     it('sends email address if it is defined', function () {
       const ticketWithEmail: any = {
         firstName: 'Jane',


### PR DESCRIPTION
## Description of the change

When creating ticket with lastName as `null` it actually creates ticket with last name set to "null".
Now we just omit the `null` value.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

