### PR TITLE
feat: use temporary api key to open ws connection

### DIFF
--- a/src/qminder-api.ts
+++ b/src/qminder-api.ts
@@ -75,7 +75,7 @@ export const setKey = (key: string) => {
  */
 export const setServer = (server: string) => {
   ApiBase.setServer(server);
-  GraphQLService.setServer(`wss://${server}:443`);
+  GraphQLService.setServer(server);
 };
 
 // VERSION is replaced with the version string from package.json during compile time

--- a/src/services/GraphQLService.ts
+++ b/src/services/GraphQLService.ts
@@ -238,7 +238,7 @@ export class GraphQLService {
     }
     this.setConnectionStatus(ConnectionStatus.CONNECTING);
     this.fetchTemporaryApiKey().then((tempApiKey: string) => {
-      this.createSocketConnection(tempApiKey)
+      this.createSocketConnection(tempApiKey);
     });
   }
 
@@ -253,8 +253,8 @@ export class GraphQLService {
     };
 
     return this.fetch(`https://${this.apiServer}/${url}`, body)
-        .then((response: Response) => response.json())
-        .then((responseJson: { key: string }) => responseJson.key);
+      .then((response: Response) => response.json())
+      .then((responseJson: { key: string }) => responseJson.key);
   }
 
   private createSocketConnection(tempApiKey: string) {

--- a/src/services/GraphQLService.ts
+++ b/src/services/GraphQLService.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import * as WebSocket from 'isomorphic-ws';
+import * as fetch from 'isomorphic-fetch';
 import { Observable, Observer, Subject } from 'rxjs';
 import { shareReplay } from 'rxjs/operators';
 import { DocumentNode } from 'graphql';
@@ -67,6 +68,8 @@ export class GraphQLService {
 
   private apiServer: string;
 
+  fetch: Function;
+
   private socket: WebSocket = null;
 
   private connectionStatus: ConnectionStatus;
@@ -87,8 +90,12 @@ export class GraphQLService {
   private connectionRetries = 0;
 
   constructor() {
-    this.setServer('wss://api.qminder.com:443');
+    this.setServer('api.qminder.com');
     this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
+    this.fetch = fetch;
+    if (typeof (fetch as any).default === 'function') {
+      this.fetch = (fetch as any).default as Function;
+    }
   }
 
   /**
@@ -230,8 +237,29 @@ export class GraphQLService {
       return;
     }
     this.setConnectionStatus(ConnectionStatus.CONNECTING);
+    this.fetchTemporaryApiKey().then((tempApiKey: string) => {
+      this.createSocketConnection(tempApiKey)
+    });
+  }
+
+  private fetchTemporaryApiKey(): Promise<string> {
+    const url = 'graphql/connection-key';
+    const body = {
+      method: 'POST',
+      mode: 'cors',
+      headers: {
+        'X-Qminder-REST-API-Key': this.apiKey,
+      },
+    };
+
+    return this.fetch(`https://${this.apiServer}/${url}`, body)
+        .then((response: Response) => response.json())
+        .then((responseJson: { key: string }) => responseJson.key);
+  }
+
+  private createSocketConnection(tempApiKey: string) {
     const socket = new WebSocket(
-      `${this.apiServer}/graphql/subscription?rest-api-key=${this.apiKey}`,
+      `wss://${this.apiServer}:443/graphql/subscription?rest-api-key=${tempApiKey}`,
     );
     this.socket = socket;
 

--- a/test/unit/GraphQLSubscriptions.test.ts
+++ b/test/unit/GraphQLSubscriptions.test.ts
@@ -3,15 +3,15 @@
 import * as WebSocket from 'isomorphic-ws';
 import { Subscriber } from 'rxjs';
 import { gql } from 'graphql-tag';
+import * as sinon from 'sinon';
 import { GraphQLService } from '../../src/services/GraphQLService';
-import * as sinon from "sinon";
 
 jest.mock('isomorphic-ws');
 
 describe('GraphQL subscriptions', () => {
   let graphqlService: GraphQLService;
   let fetchSpy: sinon.SinonStub;
-  const keyValue = "temporary_api_key";
+  const keyValue = 'temporary_api_key';
   const FAKE_RESPONSE = {
     json() {
       return { key: keyValue };
@@ -43,8 +43,12 @@ describe('GraphQL subscriptions', () => {
       graphqlService.subscribe('subscription { baba }').subscribe(() => {});
       // wait until the web socket connection was opened
       await new Promise(process.nextTick);
-      expect(fetchSpy.args[0][0]).toBe("https://api.qminder.com/graphql/connection-key")
-      expect(WebSocket).toBeCalledWith(`wss://api.qminder.com:443/graphql/subscription?rest-api-key=${keyValue}`)
+      expect(fetchSpy.args[0][0]).toBe(
+        'https://api.qminder.com/graphql/connection-key',
+      );
+      expect(WebSocket).toBeCalledWith(
+        `wss://api.qminder.com:443/graphql/subscription?rest-api-key=${keyValue}`,
+      );
     });
 
     it('fires an Apollo compliant subscribe event, when a new subscriber comes in', async () => {

--- a/test/unit/GraphQLSubscriptions.test.ts
+++ b/test/unit/GraphQLSubscriptions.test.ts
@@ -4,13 +4,24 @@ import * as WebSocket from 'isomorphic-ws';
 import { Subscriber } from 'rxjs';
 import { gql } from 'graphql-tag';
 import { GraphQLService } from '../../src/services/GraphQLService';
+import * as sinon from "sinon";
 
 jest.mock('isomorphic-ws');
 
 describe('GraphQL subscriptions', () => {
   let graphqlService: GraphQLService;
+  let fetchSpy: sinon.SinonStub;
+  const keyValue = "temporary_api_key";
+  const FAKE_RESPONSE = {
+    json() {
+      return { key: keyValue };
+    },
+  };
+
   beforeEach(() => {
     graphqlService = new GraphQLService();
+    fetchSpy = sinon.stub(graphqlService, 'fetch');
+    fetchSpy.onCall(0).resolves(FAKE_RESPONSE);
   });
 
   afterEach(() => {
@@ -28,9 +39,19 @@ describe('GraphQL subscriptions', () => {
   });
 
   describe('.subscribe', () => {
-    it('fires an Apollo compliant subscribe event, when a new subscriber comes in', () => {
+    it('fetches temporary api key when a new connection is opened', async () => {
+      graphqlService.subscribe('subscription { baba }').subscribe(() => {});
+      // wait until the web socket connection was opened
+      await new Promise(process.nextTick);
+      expect(fetchSpy.args[0][0]).toBe("https://api.qminder.com/graphql/connection-key")
+      expect(WebSocket).toBeCalledWith(`wss://api.qminder.com:443/graphql/subscription?rest-api-key=${keyValue}`)
+    });
+
+    it('fires an Apollo compliant subscribe event, when a new subscriber comes in', async () => {
       const sendMessageSpy = jest.spyOn(graphqlService as any, 'sendMessage');
       graphqlService.subscribe('subscription { baba }').subscribe(() => {});
+      // wait until the web socket connection was opened
+      await new Promise(process.nextTick);
       expect(WebSocket).toHaveBeenCalled();
       expect((graphqlService as any).subscriptions.length).toBe(1);
       expect(sendMessageSpy).toHaveBeenCalledWith(
@@ -54,7 +75,7 @@ describe('GraphQL subscriptions', () => {
       expect(stopSubscriptionSpy).toHaveBeenCalledWith('1');
     });
 
-    it('works with graphql-tag generated documents', () => {
+    it('works with graphql-tag generated documents', async () => {
       const sendMessageSpy = jest.spyOn(graphqlService as any, 'sendMessage');
       graphqlService
         .subscribe(
@@ -65,6 +86,8 @@ describe('GraphQL subscriptions', () => {
           `,
         )
         .subscribe(() => {});
+      // wait until the web socket connection was opened
+      await new Promise(process.nextTick);
       expect(WebSocket).toHaveBeenCalled();
       expect((graphqlService as any).subscriptions.length).toBe(1);
       expect(sendMessageSpy).toHaveBeenCalledWith(
@@ -76,7 +99,7 @@ describe('GraphQL subscriptions', () => {
       );
     });
 
-    it('does not automatically add leading "subscription {" and trailing "}"', () => {
+    it('does not automatically add leading "subscription {" and trailing "}"', async () => {
       const sendMessageSpy = jest.spyOn(graphqlService as any, 'sendMessage');
       graphqlService
         .subscribe(
@@ -87,6 +110,8 @@ describe('GraphQL subscriptions', () => {
           `,
         )
         .subscribe(() => {});
+      // wait until the web socket connection was opened
+      await new Promise(process.nextTick);
       expect(WebSocket).toHaveBeenCalled();
       expect((graphqlService as any).subscriptions.length).toBe(1);
       expect(sendMessageSpy).toHaveBeenCalledWith(
@@ -125,13 +150,15 @@ describe('GraphQL subscriptions', () => {
   });
 
   describe('receiving messages', () => {
-    it('when receiving a published message for a subscription that does not exist anymore, it does not throw', () => {
+    it('when receiving a published message for a subscription that does not exist anymore, it does not throw', async () => {
       expect(
         Object.keys((graphqlService as any).subscriptionObserverMap).length,
       ).toBe(0);
       const subscription = graphqlService
         .subscribe('subscription { baba }')
         .subscribe(() => {});
+      // wait until the web socket connection was opened
+      await new Promise(process.nextTick);
       subscription.unsubscribe();
       const internalSock = (graphqlService as any).socket;
 


### PR DESCRIPTION
## Description of the change

This PR changes GraphQL API so that the provided API key is used to create a temporary API key. The newly created temporary key will be used to establish a web socket connection. In that way, we can mitigate https://github.com/Qminder/server/issues/15986.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Related issues

Related to https://github.com/Qminder/server/issues/15986

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

