### PR TITLE
feat(service): remove return to queue position MIDDLE

### DIFF
--- a/docs/classes/tickets.html
+++ b/docs/classes/tickets.html
@@ -1031,7 +1031,7 @@
 								</div>
 								<p>Returning a ticket to the queue makes the ticket&#39;s status go back to &#39;NEW&#39;, a Ticket
 									Created event will fire, and the ticket will appear back in the queue. The ticket can be
-									ordered to be first in queue, somewhere in the middle, or the last in queue, depending on
+									ordered to be first in queue or the last in queue, depending on
 								the reason the visitor needs to go back to the queue and when they will be back for service.</p>
 								<p>Only called tickets (with the status &#39;CALLED&#39;) can be returned to the queue.</p>
 							</div>
@@ -1054,8 +1054,7 @@
 								<li>
 									<h5>position: <span class="tsd-signature-type">DesiredQueuePosition</span></h5>
 									<div class="tsd-comment tsd-typography">
-										<p>The position where to place the returned ticket. Either &#39;FIRST&#39;, &#39;MIDDLE&#39;
-										or &#39;LAST&#39;.</p>
+										<p>The position where to place the returned ticket. Either &#39;FIRST&#39; or &#39;LAST&#39;.</p>
 									</div>
 								</li>
 							</ul>

--- a/docs/classes/tickets.html
+++ b/docs/classes/tickets.html
@@ -1029,10 +1029,10 @@
 								<div class="lead">
 									<p>Return a ticket to the queue.</p>
 								</div>
-								<p>Returning a ticket to the queue makes the ticket&#39;s status go back to &#39;NEW&#39;, a Ticket
-									Created event will fire, and the ticket will appear back in the queue. The ticket can be
-									ordered to be first in queue or the last in queue, depending on the reason
-									the visitor needs to go back to the queue and when they will be back for service.</p>
+								<p>Returning a ticket to the queue makes the ticket&#39;s status go back to &#39;NEW&#39;, Ticket
+									Changed and Reordered events will fire, and the ticket will appear back in the queue.
+									The ticket can be ordered to be first in queue or the last in queue, depending on
+									the reason the visitor needs to go back to the queue and when they will be back for service.</p>
 								<p>Only called tickets (with the status &#39;CALLED&#39;) can be returned to the queue.</p>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/tickets.html
+++ b/docs/classes/tickets.html
@@ -1031,8 +1031,8 @@
 								</div>
 								<p>Returning a ticket to the queue makes the ticket&#39;s status go back to &#39;NEW&#39;, a Ticket
 									Created event will fire, and the ticket will appear back in the queue. The ticket can be
-									ordered to be first in queue or the last in queue, depending on
-								the reason the visitor needs to go back to the queue and when they will be back for service.</p>
+									ordered to be first in queue or the last in queue, depending on the reason
+									the visitor needs to go back to the queue and when they will be back for service.</p>
 								<p>Only called tickets (with the status &#39;CALLED&#39;) can be returned to the queue.</p>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/services/TicketService.ts
+++ b/src/services/TicketService.ts
@@ -191,8 +191,7 @@ interface TicketSearchCriteria {
 
 /**
  * Represents a position in the queue where the ticket should go when returning it to the queue.
- * They should either be the first in line, somewhere in the center (when they will be back
- * soon), or the last in line.
+ * They should either be the first in line or the last in line.
  */
 type DesiredQueuePosition = 'FIRST' | 'LAST';
 

--- a/src/services/TicketService.ts
+++ b/src/services/TicketService.ts
@@ -194,7 +194,7 @@ interface TicketSearchCriteria {
  * They should either be the first in line, somewhere in the center (when they will be back
  * soon), or the last in line.
  */
-type DesiredQueuePosition = 'FIRST' | 'MIDDLE' | 'LAST';
+type DesiredQueuePosition = 'FIRST' | 'LAST';
 
 /** This error is thrown when a Line ID is not passed to the API method, or when its type is not
  *  a number.
@@ -766,7 +766,7 @@ export default class TicketService {
    *
    * Returning a ticket to the queue makes the ticket's status go back to 'NEW', a Ticket
    * Created event will fire, and the ticket will appear back in the queue. The ticket can be
-   * ordered to be first in queue, somewhere in the middle, or the last in queue, depending on
+   * ordered to be first in queue or the last in queue, depending on
    * the reason the visitor needs to go back to the queue and when they will be back for service.
    *
    * Only called tickets (with the status 'CALLED') can be returned to the queue.
@@ -775,8 +775,7 @@ export default class TicketService {
    * Ticket object.
    * @param user  The user that returned the ticket to the queue. The user ID can be used instead
    * of the User object.
-   * @param position  The position where to place the returned ticket. Either 'FIRST', 'MIDDLE'
-   * or 'LAST'.
+   * @param position  The position where to place the returned ticket. Either 'FIRST' or 'LAST'.
    * @returns {Promise<string>} a promise that resolves to "success" if it worked, and rejects
    * if something went wrong.
    */


### PR DESCRIPTION
## Description of the change

This PR removes position MIDDLE from docs and from type declaration DesiredQueuePosition.
Also refactors ticket return to queue event initialisation description.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Related issues

Closes #378 
Related to https://github.com/Qminder/server/issues/16308

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

