### PR TITLE
feat(api-base): set GraphQL request 'Content-Type' to 'application/json'

### DIFF
--- a/src/api-base.ts
+++ b/src/api-base.ts
@@ -247,7 +247,7 @@ class ApiBase {
       method: 'POST',
       headers: {
         'X-Qminder-REST-API-Key': this.apiKey,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
       mode: 'cors',
       body: JSON.stringify(query),

--- a/src/api-base.ts
+++ b/src/api-base.ts
@@ -247,6 +247,7 @@ class ApiBase {
       method: 'POST',
       headers: {
         'X-Qminder-REST-API-Key': this.apiKey,
+        'Content-Type': 'application/json'
       },
       mode: 'cors',
       body: JSON.stringify(query),


### PR DESCRIPTION
## Description of the change

This PR sets GraphQL request header '`Content-Type`' to '`application/json`'

Testing how-to is specified in related issue.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Related issues

Related to https://github.com/Qminder/server/issues/17013

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

