### PR TITLE
fix(tooling): Change env variable name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,9 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Install Deps
         run: yarn install --immutable
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build Library
         run: yarn build
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish package to NPM
         run: yarn npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description of the change

Release failed with the following error
<img width="977" alt="image" src="https://user-images.githubusercontent.com/36738504/224277994-b366faab-0628-4c9c-902a-8bce7ca4c289.png">

Let's try to use the same secret variable that works in ui-comp

https://github.com/Qminder/ui-components/blob/master/.github/workflows/release.yml#L40

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)
