### PR TITLE
feat(graphql): Add connection error event

### DIFF
--- a/src/services/GraphQLService.ts
+++ b/src/services/GraphQLService.ts
@@ -317,6 +317,13 @@ export class GraphQLService {
         this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
         this.clearMonitoring();
         this.socket = null;
+        return;
+      }
+
+      if (this.connectionStatus === ConnectionStatus.CONNECTING) {
+        console.error(
+          `Received socket close event before a connection was established! Close code: ${event.code}`,
+        );
       }
     };
 


### PR DESCRIPTION
## Description of the change

![image](https://user-images.githubusercontent.com/36738504/235663354-66ba5b76-a6a5-4701-9956-a3be57668895.png)

> https://websockets.spec.whatwg.org//#message-example

This part of the websocket spec leads us to believe that the socket might be able to send an `onclose` event if the connection wasn't able to establish itself. Let's monitor if this really happens and if it does we can decide whether to 
- move the connection monitoring to the `onopen` event
- handle `onclose` event more accurately

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

