### PR TITLE
fix(CI): Exclude spec files from build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "declaration": true
   },
   "include": ["src/**/*"],
+  "exclude": ["**/*.spec.ts"],
   "files": ["src/index.ts"]
 }


### PR DESCRIPTION
## Description of the change

During remote-sign-in-backend investigations I accidentally saw that we include our spec files with the output. Let's remove them.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)