### PR TITLE
fix: only a single websocket is opened when subscribe() called in rapid succession

### DIFF
--- a/src/lib/services/graphql/graphql.service.ts
+++ b/src/lib/services/graphql/graphql.service.ts
@@ -254,7 +254,7 @@ export class GraphqlService {
     ) {
       return;
     }
-
+    this.setConnectionStatus(ConnectionStatus.CONNECTING);
     console.info('[Qminder API]: Connecting to websocket!');
     this.fetchTemporaryApiKey().then((temporaryApiKey: string) => {
       this.createSocketConnection(temporaryApiKey);
@@ -295,7 +295,6 @@ export class GraphqlService {
   }
 
   private createSocketConnection(temporaryApiKey: string) {
-    this.setConnectionStatus(ConnectionStatus.CONNECTING);
     this.socket = new WebSocket(
       `wss://${this.apiServer}:443/graphql/subscription?rest-api-key=${temporaryApiKey}`,
     );


### PR DESCRIPTION
## Description of the change

When a client subscribes to multiple different events in rapid succession, this library will create multiple WebSockets because of #544 .

This PR makes sure only one WebSocket is created.

<details><summary>I also checked if the unit test actually works</summary>

The test successfully detects if multiple websockets / fetch calls were performed:

```
❯ git revert -n cd3d0b44398301b85990a7b50b5154146f1e060c
❯ yarn test graphql.service
 FAIL  src/lib/services/graphql/graphql.service.spec.ts
  GraphQL service
    query
      ✓ calls ApiBase.queryGraph with the correct parameters (5 ms)
      ✓ calls ApiBase.queryGraph with both query & variables (1 ms)
      ✓ collapses whitespace and newlines (1 ms)
      ✓ throws when query is missing (18 ms)
    tag support
      ✓ GraphqlService.query works correctly when passed a gql`` tagged query (4 ms)
      ✓ GraphqlService.query works correctly when passed a long query with variables and fragments (3 ms)
    subscriptions
      .generateOperationId
        ✓ returns an incrementing string (2 ms)
      .subscribe
        .generateOperationId
          ✓ returns an incrementing string (2 ms)
        .subscribe
          ✓ fetches temporary api key when a new connection is opened (37 ms)
          ✕ opens 1 connection if multiple calls to connection key were performed (33 ms)
        with websocket cleanup
          .subscribe
            ✓ fires an Apollo compliant subscribe event, when a new subscriber comes in (4 ms)
            ✓ sends an un-subscribe message when the subscription is unsubscribe from (10 ms)
            ✓ works with graphql-tag generated documents (3 ms)
            ✓ does not automatically add leading "subscription {" and trailing "}" (3 ms)
          .stopSubscription
            ✓ deletes the subscription from the mapping of ID -> callbacks (5 ms)
          receiving messages
            ✓ when receiving a published message for a subscription that does not exist anymore, it does not throw (3 ms)

  ● GraphQL service › subscriptions › .subscribe › .subscribe › opens 1 connection if multiple calls to connection key were performed

    expect(sinon.spy).toHaveCallCount(callCount)

    Expected spy to have been called 1 time(s), instead received a spy that has been called 4 time(s)

      193 |           // wait until the web socket connection was opened
      194 |           await new Promise(process.nextTick);
    > 195 |           expect(fetchSpy).toHaveBeenCalledTimes(1);
          |                            ^
      196 |           expect(WebSocket).toHaveBeenCalledTimes(1);
      197 |         });
      198 |       });

      at Object.<anonymous> (src/lib/services/graphql/graphql.service.spec.ts:195:28)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 15 passed, 16 total
Snapshots:   0 total
Time:        4.907 s, estimated 5 s
Ran all test suites matching /graphql.service/i.

```
</details>

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Related issues

Fixes #544 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

