### PR TITLE
fix(api-base): Fix network error handling

### DIFF
--- a/src/lib/model/client-error.ts
+++ b/src/lib/model/client-error.ts
@@ -1,8 +1,0 @@
-export class ClientError extends Error {
-  error?: { [key: string]: string };
-
-  constructor(message: string, error?: { [key: string]: string }) {
-    super(message);
-    this.error = error;
-  }
-}

--- a/src/lib/model/client-error.ts
+++ b/src/lib/model/client-error.ts
@@ -1,8 +1,8 @@
 export class ClientError extends Error {
-	error?: { [key: string]: string };
+  error?: { [key: string]: string };
 
-	constructor(message: string, error?: { [key: string]: string }) {
-		super(message);
-		this.error = error;
-	}
+  constructor(message: string, error?: { [key: string]: string }) {
+    super(message);
+    this.error = error;
+  }
 }

--- a/src/lib/model/client-error.ts
+++ b/src/lib/model/client-error.ts
@@ -1,8 +1,8 @@
 export class ClientError extends Error {
-  private field: string;
+	error?: { [key: string]: string };
 
-  constructor(field: string, message: string) {
-    super(message);
-    this.field = field;
-  }
+	constructor(message: string, error?: { [key: string]: string }) {
+		super(message);
+		this.error = error;
+	}
 }

--- a/src/lib/model/errors/complex-error.ts
+++ b/src/lib/model/errors/complex-error.ts
@@ -1,0 +1,8 @@
+export class ComplexError extends Error {
+  error: { [key: string]: string };
+
+  constructor(error: { [key: string]: string }) {
+    super('Error occurred! Check error property for more information!');
+    this.error = error;
+  }
+}

--- a/src/lib/model/errors/simple-error.ts
+++ b/src/lib/model/errors/simple-error.ts
@@ -1,0 +1,5 @@
+export class SimpleError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/lib/model/errors/unknown-error.ts
+++ b/src/lib/model/errors/unknown-error.ts
@@ -1,0 +1,5 @@
+export class UnknownError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/lib/model/errors/unknown-error.ts
+++ b/src/lib/model/errors/unknown-error.ts
@@ -1,5 +1,5 @@
 export class UnknownError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor() {
+    super('Error occurred! Could not extract error message!');
   }
 }

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -1,7 +1,8 @@
 import * as sinon from 'sinon';
 import fetch from 'cross-fetch';
 import { Qminder } from '../../qminder';
-import { ClientError } from '../../model/client-error';
+import { SimpleError } from '../../model/errors/simple-error';
+import { ComplexError } from '../../model/errors/complex-error';
 
 jest.mock('cross-fetch', () => {
   const crossFetch = jest.requireActual('cross-fetch');
@@ -295,7 +296,7 @@ describe('ApiBase', () => {
 
       Qminder.ApiBase.request('TEST').then(
         () => done(new Error('Should have errored')),
-        (error: ClientError) => {
+        (error: SimpleError) => {
           expect(error.message).toEqual('Internal server error');
           done();
         },
@@ -315,7 +316,7 @@ describe('ApiBase', () => {
 
       Qminder.ApiBase.request('TEST').then(
         () => done(new Error('Should have errored')),
-        (error: ClientError) => {
+        (error: SimpleError) => {
           expect(error.message).toEqual('Oh, snap!');
           done();
         },
@@ -335,11 +336,9 @@ describe('ApiBase', () => {
 
       Qminder.ApiBase.request('TEST').then(
         () => done(new Error('Should have errored')),
-        (error: ClientError) => {
+        (error: ComplexError) => {
           expect(error.error).toEqual({ email: 'Email already in use' });
-          expect(error.message).toEqual(
-            'Request failed! More info in the error property.',
-          );
+          expect(error.message).toEqual('Error occurred! Check error property for more information!');
           done();
         },
       );
@@ -442,7 +441,7 @@ describe('ApiBase', () => {
 
       Qminder.ApiBase.queryGraph(ME_ID.request).then(
         () => done(new Error('Should have errored')),
-        (error: ClientError) => {
+        (error: SimpleError) => {
           expect(error.message).toEqual(VALIDATION_ERROR);
           done();
         },

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -289,7 +289,7 @@ describe('ApiBase', () => {
       const response: any = {
         ok: false,
         statusCode: 409,
-        error: "Internal Server Error",
+        error: 'Internal Server Error',
       };
 
       fetchSpy.mockReturnValue(new MockResponse(response));
@@ -297,7 +297,7 @@ describe('ApiBase', () => {
       Qminder.ApiBase.request('TEST').then(
         () => done(new Error('Should have errored')),
         (error: GraphQLApiError) => {
-          expect(error.message).toEqual("Internal Server Error");
+          expect(error.message).toEqual('Internal Server Error');
           done();
         },
       );

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -327,6 +327,27 @@ describe('ApiBase', () => {
       );
     });
 
+    it('should handle error with error property as string', (done) => {
+      Qminder.setKey(API_KEY);
+
+      const response: any = {
+        ok: false,
+        error: 'Internal Server Error',
+        statusCode: 409,
+      };
+
+      fetchSpy.mockReturnValue(new MockResponse(response));
+
+      Qminder.ApiBase.request('TEST').then(
+        () => done(new Error('Should have errored')),
+        (error: SimpleError) => {
+          expect(error.message).toEqual('Internal Server Error');
+          expect(error instanceof SimpleError).toBeTruthy();
+          done();
+        },
+      );
+    });
+
     it('should handle error with message in "developerMessage" property', (done) => {
       Qminder.setKey(API_KEY);
 

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -3,6 +3,7 @@ import fetch from 'cross-fetch';
 import { Qminder } from '../../qminder';
 import { SimpleError } from '../../model/errors/simple-error';
 import { ComplexError } from '../../model/errors/complex-error';
+import { UnknownError } from '../../model/errors/unknown-error';
 
 jest.mock('cross-fetch', () => {
   const crossFetch = jest.requireActual('cross-fetch');
@@ -298,6 +299,7 @@ describe('ApiBase', () => {
         () => done(new Error('Should have errored')),
         (error: SimpleError) => {
           expect(error.message).toEqual('Internal server error');
+          expect(error instanceof SimpleError).toBeTruthy();
           done();
         },
       );
@@ -316,9 +318,8 @@ describe('ApiBase', () => {
       Qminder.ApiBase.request('TEST').then(
         () => done(new Error('Should have errored')),
         (error: SimpleError) => {
-          expect(error.message).toEqual(
-            'Error occurred! Could not extract error message!',
-          );
+          expect(error.message).toEqual('Error occurred! Could not extract error message!'); 
+          expect(error instanceof UnknownError).toBeTruthy();
           done();
         },
       );
@@ -339,6 +340,7 @@ describe('ApiBase', () => {
         () => done(new Error('Should have errored')),
         (error: SimpleError) => {
           expect(error.message).toEqual('Oh, snap!');
+          expect(error instanceof SimpleError).toBeTruthy();
           done();
         },
       );
@@ -362,6 +364,7 @@ describe('ApiBase', () => {
           expect(error.message).toEqual(
             'Error occurred! Check error property for more information!',
           );
+          expect(error instanceof ComplexError).toBeTruthy();
           done();
         },
       );

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -316,7 +316,9 @@ describe('ApiBase', () => {
       Qminder.ApiBase.request('TEST').then(
         () => done(new Error('Should have errored')),
         (error: SimpleError) => {
-          expect(error.message).toEqual('Error occurred! Could not extract error message!');
+          expect(error.message).toEqual(
+            'Error occurred! Could not extract error message!',
+          );
           done();
         },
       );
@@ -357,7 +359,9 @@ describe('ApiBase', () => {
         () => done(new Error('Should have errored')),
         (error: ComplexError) => {
           expect(error.error).toEqual({ email: 'Email already in use' });
-          expect(error.message).toEqual('Error occurred! Check error property for more information!');
+          expect(error.message).toEqual(
+            'Error occurred! Check error property for more information!',
+          );
           done();
         },
       );

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -289,7 +289,7 @@ describe('ApiBase', () => {
       const response: any = {
         ok: false,
         statusCode: 409,
-        error: 'Internal server error',
+        message: 'Internal server error',
       };
 
       fetchSpy.mockReturnValue(new MockResponse(response));
@@ -298,6 +298,25 @@ describe('ApiBase', () => {
         () => done(new Error('Should have errored')),
         (error: SimpleError) => {
           expect(error.message).toEqual('Internal server error');
+          done();
+        },
+      );
+    });
+
+    it('should handle error with unrecognised response type', (done) => {
+      Qminder.setKey(API_KEY);
+
+      const response: any = {
+        ok: false,
+        statusCode: 409,
+      };
+
+      fetchSpy.mockReturnValue(new MockResponse(response));
+
+      Qminder.ApiBase.request('TEST').then(
+        () => done(new Error('Should have errored')),
+        (error: SimpleError) => {
+          expect(error.message).toEqual('Error occurred! Could not extract error message!');
           done();
         },
       );

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -318,7 +318,9 @@ describe('ApiBase', () => {
       Qminder.ApiBase.request('TEST').then(
         () => done(new Error('Should have errored')),
         (error: SimpleError) => {
-          expect(error.message).toEqual('Error occurred! Could not extract error message!'); 
+          expect(error.message).toEqual(
+            'Error occurred! Could not extract error message!',
+          );
           expect(error instanceof UnknownError).toBeTruthy();
           done();
         },

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -51,6 +51,7 @@ function generateRequestData(query: string, responseData: any): any {
 }
 
 const FAKE_RESPONSE = {
+  ok: true,
   json() {
     return { statusCode: 200 };
   },
@@ -282,12 +283,13 @@ describe('ApiBase', () => {
       });
     });
 
-    it('handles legacy error response (message)', (done) => {
+    it('handles error', (done) => {
       Qminder.setKey(API_KEY);
 
       const response: any = {
+        ok: false,
         statusCode: 409,
-        message: 'Oh, snap!',
+        error: "Internal Server Error",
       };
 
       fetchSpy.mockReturnValue(new MockResponse(response));
@@ -295,47 +297,7 @@ describe('ApiBase', () => {
       Qminder.ApiBase.request('TEST').then(
         () => done(new Error('Should have errored')),
         (error: GraphQLApiError) => {
-          expect(error).toEqual(new Error('Oh, snap!'));
-          done();
-        },
-      );
-    });
-
-    it('handles legacy error response (developerMessage)', (done) => {
-      Qminder.setKey(API_KEY);
-
-      const response: any = {
-        statusCode: 409,
-        developerMessage: 'Oh, snap!',
-      };
-
-      fetchSpy.mockReturnValue(new MockResponse(response));
-
-      Qminder.ApiBase.request('TEST').then(
-        () => done(new Error('Should have errored')),
-        (error: GraphQLApiError) => {
-          expect(error).toEqual(new Error('Oh, snap!'));
-          done();
-        },
-      );
-    });
-
-    it('handles client error', (done) => {
-      Qminder.setKey(API_KEY);
-
-      const response: any = {
-        statusCode: 409,
-        error: { email: 'Email already in use' },
-      };
-
-      fetchSpy.mockReturnValue(new MockResponse(response));
-
-      Qminder.ApiBase.request('TEST').then(
-        () => done(new Error('Should have errored')),
-        (error: GraphQLApiError) => {
-          expect(error).toEqual(
-            new ClientError('email', 'Email already in use'),
-          );
+          expect(error.message).toEqual("Internal Server Error");
           done();
         },
       );

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -314,11 +314,11 @@ describe('ApiBase', () => {
       fetchSpy.mockReturnValue(new MockResponse(response));
 
       Qminder.ApiBase.request('TEST').then(
-          () => done(new Error('Should have errored')),
-          (error: ClientError) => {
-            expect(error.message).toEqual('Oh, snap!');
-            done();
-          },
+        () => done(new Error('Should have errored')),
+        (error: ClientError) => {
+          expect(error.message).toEqual('Oh, snap!');
+          done();
+        },
       );
     });
 
@@ -334,19 +334,22 @@ describe('ApiBase', () => {
       fetchSpy.mockReturnValue(new MockResponse(response));
 
       Qminder.ApiBase.request('TEST').then(
-          () => done(new Error('Should have errored')),
-          (error: ClientError) => {
-            expect(error.error).toEqual({ email: 'Email already in use' });
-            expect(error.message).toEqual('Request failed! More info in the error property.');
-            done();
+        () => done(new Error('Should have errored')),
+        (error: ClientError) => {
+          expect(error.error).toEqual({ email: 'Email already in use' });
+          expect(error.message).toEqual(
+            'Request failed! More info in the error property.',
+          );
+          done();
         },
       );
     });
   });
 
   describe('queryGraph()', () => {
-    const VALIDATION_ERROR = "Validation error of type FieldUndefined: Field 'x' in type 'Account' is undefined @ 'account/x'";
-    
+    const VALIDATION_ERROR =
+      "Validation error of type FieldUndefined: Field 'x' in type 'Account' is undefined @ 'account/x'";
+
     const ME_ID = generateRequestData('{ me { id } }', {
       me: {
         id: 12345,

--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -282,7 +282,7 @@ describe('ApiBase', () => {
       });
     });
 
-    it('handles error when return object has "error" property', (done) => {
+    it('should handle error with message in "error" property', (done) => {
       Qminder.setKey(API_KEY);
 
       const response: any = {
@@ -302,7 +302,7 @@ describe('ApiBase', () => {
       );
     });
 
-    it('handles error when return object has "developerMessage" property', (done) => {
+    it('should handle error with message in "developerMessage" property', (done) => {
       Qminder.setKey(API_KEY);
 
       const response: any = {
@@ -322,7 +322,7 @@ describe('ApiBase', () => {
       );
     });
 
-    it('handles client error', (done) => {
+    it('should handle error with complex error in "error" property', (done) => {
       Qminder.setKey(API_KEY);
 
       const response: any = {
@@ -431,7 +431,7 @@ describe('ApiBase', () => {
       );
     });
 
-    it('resolves with response, even if response has errors', (done) => {
+    it('should resolve with response, even if response has errors', (done) => {
       Qminder.ApiBase.setKey('testing');
       fetchSpy.mockImplementation(() =>
         Promise.resolve(new MockResponse(ERROR_UNDEFINED_FIELD)),

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -174,7 +174,7 @@ export class ApiBase {
    * response.
    * @param query required: GraphQL query, for example "{ me { email } }", or
    * "query X($id: ID!) { location($id) { name } }"
-   * @returns a Promise that resolves to the entire response ({ status, data?, errors? ... })
+   * @returns a Promise that resolves to the entire response ({ statusCode, data?, errors? ... })
    * @throws when the API key is missing or invalid, or when errors in the
    * response are found
    */

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -3,6 +3,7 @@ import { GraphQLError } from 'graphql';
 import { GraphqlResponse } from '../../model/graphql-response.js';
 import { SimpleError } from '../../model/errors/simple-error.js';
 import { ComplexError } from '../../model/errors/complex-error.js';
+import { UnknownError } from '../../model/errors/unknown-error.js';
 
 type HTTPMethod =
   | 'GET'
@@ -215,7 +216,7 @@ export class ApiBase {
       return new ComplexError(response.error);
     }
 
-    return new SimpleError('Error occurred! Could not extract error message!');
+    return new UnknownError('Error occurred! Could not extract error message!');
   }
 
   private static extractGraphQLError(response: {

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -203,8 +203,8 @@ export class ApiBase {
   }
 
   private static extractError(response: any): Error {
-    if (typeof response.error === 'string') {
-      return new SimpleError(response.error);
+    if (response.message) {
+      return new SimpleError(response.message);
     }
 
     if (response.developerMessage) {
@@ -214,6 +214,8 @@ export class ApiBase {
     if (Object.prototype.hasOwnProperty.call(response, 'error')) {
       return new ComplexError(response.error);
     }
+    
+    return new SimpleError('Error occurred! Could not extract error message!')
   }
 
   private static extractGraphQLError(response: {

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -212,6 +212,10 @@ export class ApiBase {
       return new SimpleError(response.developerMessage);
     }
 
+    if (typeof response.error === 'string') {
+      return new SimpleError(response.error);
+    }
+
     if (Object.prototype.hasOwnProperty.call(response, 'error')) {
       return new ComplexError(response.error);
     }

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch';
 import { GraphqlResponse } from '../../model/graphql-response.js';
-import { ClientError } from '../../model/client-error';
+import { ClientError } from '../../model/client-error.js';
 import { GraphQLError } from 'graphql';
 
 type HTTPMethod =

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -216,7 +216,7 @@ export class ApiBase {
       return new ComplexError(response.error);
     }
 
-    return new UnknownError('Error occurred! Could not extract error message!');
+    return new UnknownError();
   }
 
   private static extractGraphQLError(response: {

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -214,8 +214,8 @@ export class ApiBase {
     if (Object.prototype.hasOwnProperty.call(response, 'error')) {
       return new ComplexError(response.error);
     }
-    
-    return new SimpleError('Error occurred! Could not extract error message!')
+
+    return new SimpleError('Error occurred! Could not extract error message!');
   }
 
   private static extractGraphQLError(response: {

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -1,7 +1,7 @@
 import fetch from 'cross-fetch';
+import { GraphQLError } from 'graphql';
 import { GraphqlResponse } from '../../model/graphql-response.js';
 import { ClientError } from '../../model/client-error.js';
-import { GraphQLError } from 'graphql';
 
 type HTTPMethod =
   | 'GET'

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -153,12 +153,13 @@ export class ApiBase {
 
     try {
       const response = await fetch(`https://${this.apiServer}/v1/${url}`, init);
-
+      const parsedResponse = await response.json();
+      
       if (!response.ok) {
-        throw new Error(`Request failed!`)  
+        throw new Error(parsedResponse.error)  
       }
 
-      return await response.json();
+      return parsedResponse;
     } catch (e: any) {
       if (e instanceof Error) {
         throw new Error(e.message);

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { GraphQLError } from 'graphql';
 import { GraphqlResponse } from '../../model/graphql-response.js';
-import { ClientError } from '../../model/client-error.js';
+import { SimpleError } from '../../model/errors/simple-error.js';
+import { ComplexError } from '../../model/errors/complex-error.js';
 
 type HTTPMethod =
   | 'GET'
@@ -201,27 +202,24 @@ export class ApiBase {
       });
   }
 
-  private static extractError(response: any): ClientError {
+  private static extractError(response: any): Error {
     if (typeof response.error === 'string') {
-      return new ClientError(response.error);
+      return new SimpleError(response.error);
     }
 
     if (response.developerMessage) {
-      return new ClientError(response.developerMessage);
+      return new SimpleError(response.developerMessage);
     }
 
     if (Object.prototype.hasOwnProperty.call(response, 'error')) {
-      return new ClientError(
-        'Request failed! More info in the error property.',
-        response.error,
-      );
+      return new ComplexError(response.error);
     }
   }
 
   private static extractGraphQLError(response: {
     errors: GraphQLError[];
-  }): ClientError {
-    return new ClientError(
+  }): Error {
+    return new SimpleError(
       response.errors.map((error) => error.message).join('\n'),
     );
   }

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -200,22 +200,29 @@ export class ApiBase {
         return responseJson as Promise<GraphqlResponse>;
       });
   }
-  
+
   private static extractError(response: any): ClientError {
     if (typeof response.error === 'string') {
       return new ClientError(response.error);
     }
-    
+
     if (response.developerMessage) {
       return new ClientError(response.developerMessage);
     }
-    
+
     if (Object.prototype.hasOwnProperty.call(response, 'error')) {
-      return new ClientError('Request failed! More info in the error property.', response.error);
+      return new ClientError(
+        'Request failed! More info in the error property.',
+        response.error,
+      );
     }
   }
-  
-  private static extractGraphQLError(response: { errors: GraphQLError[] }): ClientError {
-    return new ClientError(response.errors.map((error) => error.message).join('\n'));
+
+  private static extractGraphQLError(response: {
+    errors: GraphQLError[];
+  }): ClientError {
+    return new ClientError(
+      response.errors.map((error) => error.message).join('\n'),
+    );
   }
 }

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -154,9 +154,9 @@ export class ApiBase {
     try {
       const response = await fetch(`https://${this.apiServer}/v1/${url}`, init);
       const parsedResponse = await response.json();
-      
+
       if (!response.ok) {
-        throw new Error(parsedResponse.error)  
+        throw new Error(parsedResponse.error);
       }
 
       return parsedResponse;

--- a/src/lib/services/webhooks/webhook.service.ts
+++ b/src/lib/services/webhooks/webhook.service.ts
@@ -29,7 +29,7 @@ export const WebhookService = {
    * ```
    * @param url  the public URL to receive the webhooks, such as https://example.com/webhook
    * @returns a Webhook object with the webhook's ID and HMAC secret.
-   * @throws ERROR_NO_URL when the URL was not provided
+   * @throws {SimpleError}
    * @see Webhook
    */
   create,
@@ -55,7 +55,7 @@ export const WebhookService = {
    * ```
    * @param webhook  the Webhook object or the webhook ID.
    * @returns a promise that resolves when the API call worked, and rejects when it failed.
-   * @throws {Error} ERROR_NO_WEBHOOK_ID when the webhook ID is not provided or is not a number
+   * @throws {SimpleError}
    */
   remove,
 };

--- a/src/lib/services/webhooks/webhook.ts
+++ b/src/lib/services/webhooks/webhook.ts
@@ -1,13 +1,10 @@
-import { ApiBase, SuccessResponse } from '../api-base/api-base.js';
+import { ApiBase } from '../api-base/api-base.js';
 import { Webhook } from '../../model/webhook.js';
 import { extractId, IdOrObject } from '../../util/id-or-object.js';
 
 export const ERROR_NO_URL = 'No URL provided';
-/** @hidden */
-export const ERROR_NO_WEBHOOK_ID = 'No Webhook ID provided';
 
 type CreateWebhookResponse = Webhook;
-type DeleteWebhookResponse = SuccessResponse;
 
 export function create(url: string): Promise<Webhook> {
   if (!url || typeof url !== 'string') {
@@ -20,9 +17,7 @@ export function create(url: string): Promise<Webhook> {
   ) as Promise<CreateWebhookResponse>;
 }
 
-export function remove(
-  webhook: IdOrObject<Webhook>,
-): Promise<DeleteWebhookResponse> {
+export function remove(webhook: IdOrObject<Webhook>): Promise<void> {
   const id = extractId(webhook);
   return ApiBase.request(`webhooks/${id}`, undefined, 'DELETE');
 }

--- a/src/lib/util/errors.ts
+++ b/src/lib/util/errors.ts
@@ -1,9 +1,0 @@
-import { GraphQLError } from 'graphql';
-
-export class GraphQLApiError extends Error {
-  message: string;
-  constructor(errors: GraphQLError[]) {
-    super();
-    this.message = errors.map((error) => error.message).join('\n');
-  }
-}

--- a/src/public-api/model.ts
+++ b/src/public-api/model.ts
@@ -13,3 +13,4 @@ export { User } from '../lib/model/user.js';
 export { Webhook } from '../lib/model/webhook.js';
 export { SimpleError } from '../lib/model/errors/simple-error.js';
 export { ComplexError } from '../lib/model/errors/complex-error.js';
+export { UnknownError } from '../lib/model/errors/unknown-error.js';

--- a/src/public-api/model.ts
+++ b/src/public-api/model.ts
@@ -1,6 +1,5 @@
 export { TicketCreationParameters } from '../lib/model/ticket-creation-parameters.js';
 export { GraphqlResponse } from '../lib/model/graphql-response.js';
-export { ClientError } from '../lib/model/client-error.js';
 export { ConnectionStatus } from '../lib/model/connection-status.js';
 export { Desk } from '../lib/model/desk.js';
 export { Device } from '../lib/model/device.js';
@@ -12,3 +11,5 @@ export { TicketLabel } from '../lib/model/ticket-label.js';
 export { Ticket } from '../lib/model/ticket.js';
 export { User } from '../lib/model/user.js';
 export { Webhook } from '../lib/model/webhook.js';
+export { SimpleError } from '../lib/model/errors/simple-error.js'
+export { ComplexError } from '../lib/model/errors/complex-error.js'

--- a/src/public-api/model.ts
+++ b/src/public-api/model.ts
@@ -11,5 +11,5 @@ export { TicketLabel } from '../lib/model/ticket-label.js';
 export { Ticket } from '../lib/model/ticket.js';
 export { User } from '../lib/model/user.js';
 export { Webhook } from '../lib/model/webhook.js';
-export { SimpleError } from '../lib/model/errors/simple-error.js'
-export { ComplexError } from '../lib/model/errors/complex-error.js'
+export { SimpleError } from '../lib/model/errors/simple-error.js';
+export { ComplexError } from '../lib/model/errors/complex-error.js';


### PR DESCRIPTION
## Description of the change

Current implementation of api-base.request() recognised errors by the returned `statusCode` property.

Webhook removal endpoint returned `status` instead of `statusCode`.

I asked Stanislav if the `status` property is the standard as of now. He said no and encouraged me to use the actual request status instead of statusCode from the returned json.

So I tried out the [MDN spec](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful) way of checking the response status and it worked as expected.

One more thing: I changed the return type of the Webhook request to from `Promise<DeleteWebhookResponse>` to `Promise<void>`. There's no advantage in sending the responseCode instead of using Promise.resolve and Promise.reject callbacks.

## Breaking change

Migration GH issue: https://github.com/Qminder/server/issues/18735


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

