### PR TITLE
feat(webhooks): allow setting custom headers

### DIFF
--- a/src/lib/services/api-base/api-base.spec.ts
+++ b/src/lib/services/api-base/api-base.spec.ts
@@ -177,7 +177,7 @@ describe('ApiBase', () => {
       Qminder.setKey(API_KEY);
       const url = 'https://api.qminder.com/v1/TEST';
 
-      Qminder.ApiBase.request('TEST', { id: 1 }).then(() => {
+      Qminder.ApiBase.request('TEST', { body: { id: 1 } }).then(() => {
         expect(fetchSpy.mock.calls[0][1].body).toEqual('id=1');
         expect(fetchSpy.mock.calls[0][1].method).toEqual('POST');
         expect(fetchSpy.mock.calls[0][0]).toEqual(url);
@@ -189,7 +189,7 @@ describe('ApiBase', () => {
       Qminder.setKey(API_KEY);
       const url = 'https://api.qminder.com/v1/TEST';
 
-      Qminder.ApiBase.request('TEST', undefined, 'POST').then(() => {
+      Qminder.ApiBase.request('TEST', { method: 'POST' }).then(() => {
         expect(fetchSpy.mock.calls[0][1].method).toEqual('POST');
         expect(fetchSpy.mock.calls[0][0]).toEqual(url);
         done();
@@ -205,7 +205,7 @@ describe('ApiBase', () => {
         lastName: 'Smith',
       };
 
-      Qminder.ApiBase.request('TEST', body).then(() => {
+      Qminder.ApiBase.request('TEST', { body: body }).then(() => {
         expect(fetchSpy.mock.calls[0][1].body).toEqual(
           'id=5&firstName=John&lastName=Smith',
         );
@@ -224,7 +224,7 @@ describe('ApiBase', () => {
         lastName: 'Smith',
       };
 
-      Qminder.ApiBase.request('TEST', body).then(() => {
+      Qminder.ApiBase.request('TEST', { body: body }).then(() => {
         expect(fetchSpy.mock.calls[0][1].headers['Content-Type']).toEqual(
           'application/x-www-form-urlencoded',
         );
@@ -233,7 +233,7 @@ describe('ApiBase', () => {
       });
     });
 
-    it('sets the HTTP header Idempotency-Key if idempotencyKey has been provided', (done) => {
+    it('sets the custom HTTP headers if provided', (done) => {
       Qminder.setKey(API_KEY);
       const url = 'https://api.qminder.com/v1/TEST';
       const body = {
@@ -242,13 +242,20 @@ describe('ApiBase', () => {
         lastName: 'Smith',
       };
 
-      Qminder.ApiBase.request('TEST', body, undefined, '9e3a333e').then(() => {
+      const headers = {
+        'X-Qminder-Test-Header': 'test',
+      };
+
+      Qminder.ApiBase.request('TEST', {
+        body: body,
+        headers: headers,
+      }).then(() => {
         expect(fetchSpy.mock.calls[0][1].body).toEqual(
           'id=5&firstName=John&lastName=Smith',
         );
-        expect(fetchSpy.mock.calls[0][1].headers['Idempotency-Key']).toEqual(
-          '9e3a333e',
-        );
+        expect(
+          fetchSpy.mock.calls[0][1].headers['X-Qminder-Test-Header'],
+        ).toEqual('test');
         expect(fetchSpy.mock.calls[0][0]).toEqual(url);
         done();
       });
@@ -259,14 +266,16 @@ describe('ApiBase', () => {
       const url = 'https://api.qminder.com/v1/TEST';
       const body = JSON.stringify([123, 456, 789]);
 
-      Qminder.ApiBase.request('TEST', body, 'POST').then(() => {
-        expect(fetchSpy.mock.calls[0][1].body).toEqual(body);
-        expect(fetchSpy.mock.calls[0][1].headers['Content-Type']).toEqual(
-          'application/json',
-        );
-        expect(fetchSpy.mock.calls[0][0]).toEqual(url);
-        done();
-      });
+      Qminder.ApiBase.request('TEST', { body: body, method: 'POST' }).then(
+        () => {
+          expect(fetchSpy.mock.calls[0][1].body).toEqual(body);
+          expect(fetchSpy.mock.calls[0][1].headers['Content-Type']).toEqual(
+            'application/json',
+          );
+          expect(fetchSpy.mock.calls[0][0]).toEqual(url);
+          done();
+        },
+      );
     });
 
     it('sends objects as www-form-urlencoded', (done) => {
@@ -274,14 +283,16 @@ describe('ApiBase', () => {
       const url = 'https://api.qminder.com/v1/TEST';
       const body = { a: 'test' };
 
-      Qminder.ApiBase.request('TEST', body, 'POST').then(() => {
-        expect(fetchSpy.mock.calls[0][1].body).toEqual('a=test');
-        expect(fetchSpy.mock.calls[0][1].headers['Content-Type']).toEqual(
-          'application/x-www-form-urlencoded',
-        );
-        expect(fetchSpy.mock.calls[0][0]).toEqual(url);
-        done();
-      });
+      Qminder.ApiBase.request('TEST', { body: body, method: 'POST' }).then(
+        () => {
+          expect(fetchSpy.mock.calls[0][1].body).toEqual('a=test');
+          expect(fetchSpy.mock.calls[0][1].headers['Content-Type']).toEqual(
+            'application/x-www-form-urlencoded',
+          );
+          expect(fetchSpy.mock.calls[0][0]).toEqual(url);
+          done();
+        },
+      );
     });
 
     it('should handle error with message in "error" property', (done) => {

--- a/src/lib/services/device/device.ts
+++ b/src/lib/services/device/device.ts
@@ -19,11 +19,10 @@ export function edit(tv: IdOrObject<Device>, newName: string): Promise<Device> {
   if (!newName || typeof newName !== 'string') {
     throw new Error('TV name not provided');
   }
-  return ApiBase.request(
-    `tv/${tvId}`,
-    { name: newName },
-    'POST',
-  ) as Promise<Device>;
+  return ApiBase.request(`tv/${tvId}`, {
+    body: { name: newName },
+    method: 'POST',
+  }) as Promise<Device>;
 }
 
 export function remove(
@@ -33,7 +32,7 @@ export function remove(
   if (!tvId || typeof tvId !== 'string') {
     throw new Error('TV ID not provided');
   }
-  return ApiBase.request(`tv/${tvId}`, undefined, 'DELETE') as Promise<{
+  return ApiBase.request(`tv/${tvId}`, { method: 'DELETE' }) as Promise<{
     statusCode: number;
   }>;
 }

--- a/src/lib/services/line/line.ts
+++ b/src/lib/services/line/line.ts
@@ -39,11 +39,10 @@ export function create(
   if (!line.name || typeof line.name !== 'string') {
     throw new Error('Cannot create a line without a line name.');
   }
-  return ApiBase.request(
-    `locations/${locationId}/lines`,
-    line,
-    'POST',
-  ) as Promise<Line>;
+  return ApiBase.request(`locations/${locationId}/lines`, {
+    body: line,
+    method: 'POST',
+  }) as Promise<Line>;
 }
 
 export function update(line: LineUpdateParameters): Promise<any> {
@@ -67,7 +66,10 @@ export function update(line: LineUpdateParameters): Promise<any> {
   }
 
   const data = { name: lineName, color: lineColor };
-  return ApiBase.request(`lines/${lineId}`, data, 'POST') as Promise<any>;
+  return ApiBase.request(`lines/${lineId}`, {
+    body: data,
+    method: 'POST',
+  }) as Promise<any>;
 }
 
 export function enable(line: IdOrObject<Line>): Promise<any> {
@@ -75,11 +77,9 @@ export function enable(line: IdOrObject<Line>): Promise<any> {
   if (!lineId || typeof lineId !== 'string') {
     throw new Error('Line ID invalid or missing.');
   }
-  return ApiBase.request(
-    `lines/${lineId}/enable`,
-    undefined,
-    'POST',
-  ) as Promise<any>;
+  return ApiBase.request(`lines/${lineId}/enable`, {
+    method: 'POST',
+  }) as Promise<any>;
 }
 
 export function disable(line: IdOrObject<Line>): Promise<any> {
@@ -87,11 +87,9 @@ export function disable(line: IdOrObject<Line>): Promise<any> {
   if (!lineId || typeof lineId !== 'string') {
     throw new Error('Line ID invalid or missing.');
   }
-  return ApiBase.request(
-    `lines/${lineId}/disable`,
-    undefined,
-    'POST',
-  ) as Promise<any>;
+  return ApiBase.request(`lines/${lineId}/disable`, {
+    method: 'POST',
+  }) as Promise<any>;
 }
 
 export function archive(line: IdOrObject<Line>): Promise<any> {
@@ -99,11 +97,9 @@ export function archive(line: IdOrObject<Line>): Promise<any> {
   if (!lineId || typeof lineId !== 'string') {
     throw new Error('Line ID invalid or missing.');
   }
-  return ApiBase.request(
-    `lines/${lineId}/archive`,
-    undefined,
-    'POST',
-  ) as Promise<any>;
+  return ApiBase.request(`lines/${lineId}/archive`, {
+    method: 'POST',
+  }) as Promise<any>;
 }
 
 export function unarchive(line: IdOrObject<Line>): Promise<any> {
@@ -112,11 +108,9 @@ export function unarchive(line: IdOrObject<Line>): Promise<any> {
   if (!lineId || typeof lineId !== 'string') {
     throw new Error('Line ID invalid or missing.');
   }
-  return ApiBase.request(
-    `lines/${lineId}/unarchive`,
-    undefined,
-    'POST',
-  ) as Promise<any>;
+  return ApiBase.request(`lines/${lineId}/unarchive`, {
+    method: 'POST',
+  }) as Promise<any>;
 }
 
 export function deleteLine(line: IdOrObject<Line>): Promise<any> {
@@ -125,9 +119,7 @@ export function deleteLine(line: IdOrObject<Line>): Promise<any> {
   if (!lineId || typeof lineId !== 'string') {
     throw new Error('Line ID invalid or missing.');
   }
-  return ApiBase.request(
-    `lines/${lineId}`,
-    undefined,
-    'DELETE',
-  ) as Promise<any>;
+  return ApiBase.request(`lines/${lineId}`, {
+    method: 'DELETE',
+  }) as Promise<any>;
 }

--- a/src/lib/services/ticket/ticket.service.spec.ts
+++ b/src/lib/services/ticket/ticket.service.spec.ts
@@ -24,9 +24,11 @@ describe('Ticket service', function () {
         { id: 3, line: 125 },
       ],
     };
+
     const ticketsWithMessages = {
       data: tickets.data.map((each) => ({ ...each, messages: [] })),
     };
+
     it('searches based on lines', function (done) {
       const request = { line: [123, 124, 125] };
       requestStub.onCall(0).resolves(tickets);
@@ -44,6 +46,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('if line is a number, not an array, the call still functions correctly', function (done) {
       const request = { line: 123 };
       requestStub.resolves(tickets);
@@ -62,6 +65,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on location', function (done) {
       const request = { location: 111 };
       requestStub.onCall(0).resolves(tickets);
@@ -79,6 +83,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on statuses', function (done) {
       const request: any = { status: ['NEW', 'CALLED', 'SERVED'] };
       requestStub.onCall(0).resolves(tickets);
@@ -98,6 +103,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('if status is a string, not an array, the call still functions correctly', function (done) {
       const request = { status: 'CALLED' };
       requestStub.resolves(tickets);
@@ -116,6 +122,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on caller (passed as a number)', function (done) {
       const request = { caller: 111 };
       requestStub.onCall(0).resolves(tickets);
@@ -133,6 +140,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on caller (passed as a User)', function (done) {
       const request = { caller: { id: 111 } };
       requestStub.onCall(0).resolves(tickets);
@@ -150,6 +158,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on min created time (ISO8601)', function (done) {
       const request = { minCreated: '2017-09-02T12:48:10Z' };
       requestStub.onCall(0).resolves(tickets);
@@ -169,6 +178,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on min created time (Unix)', function (done) {
       const request = { minCreated: 1507809281 };
       requestStub.onCall(0).resolves(tickets);
@@ -186,6 +196,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on max created time (ISO8601)', function (done) {
       const request = { maxCreated: '2017-09-02T12:48:10Z' };
       requestStub.onCall(0).resolves(tickets);
@@ -205,6 +216,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on max created time (Unix)', function (done) {
       const request = { maxCreated: 1507809281 };
       requestStub.onCall(0).resolves(tickets);
@@ -222,6 +234,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on min called time (ISO8601)', function (done) {
       const request = { minCalled: '2017-09-02T12:48:10Z' };
       requestStub.onCall(0).resolves(tickets);
@@ -241,6 +254,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on min called time (Unix)', function (done) {
       const request = { minCalled: 1507809281 };
       requestStub.onCall(0).resolves(tickets);
@@ -258,6 +272,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on max called time (ISO8601)', function (done) {
       const request = { maxCalled: '2017-09-02T12:48:10Z' };
       requestStub.onCall(0).resolves(tickets);
@@ -277,6 +292,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on max called time (Unix)', function (done) {
       const request = { maxCalled: 1507809281 };
       requestStub.onCall(0).resolves(tickets);
@@ -294,6 +310,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('sets a limit', function (done) {
       const request = { limit: 5 };
       requestStub.onCall(0).resolves(tickets);
@@ -309,6 +326,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('sets the order', function (done) {
       const request = { order: 'id ASC' };
       requestStub.onCall(0).resolves(tickets);
@@ -327,6 +345,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('allows setting responseScope to MESSAGES', function (done) {
       const request = { responseScope: 'MESSAGES' };
 
@@ -345,6 +364,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('combines multiple searched parameters successfully', function (done) {
       const request: any = {
         responseScope: 'MESSAGES',
@@ -371,6 +391,7 @@ describe('Ticket service', function () {
       );
     });
   });
+
   describe('count()', function () {
     const tickets = {
       data: [
@@ -379,9 +400,11 @@ describe('Ticket service', function () {
         { id: 3, line: 125 },
       ],
     };
+
     const ticketsWithMessages = {
       data: tickets.data.map((each) => ({ ...each, messages: [] })),
     };
+
     it('searches based on lines', function (done) {
       const request = { line: [123, 124, 125] };
       requestStub.onCall(0).resolves(tickets);
@@ -399,6 +422,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('if line is a number, not an array, the call still functions correctly', function (done) {
       const request = { line: 123 };
       requestStub.resolves(tickets);
@@ -415,6 +439,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on location', function (done) {
       const request = { location: 111 };
       requestStub.onCall(0).resolves(tickets);
@@ -432,6 +457,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on statuses', function (done) {
       const request: any = { status: ['NEW', 'CALLED', 'SERVED'] };
       requestStub.onCall(0).resolves(tickets);
@@ -451,6 +477,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('if status is a string, not an array, the call still functions correctly', function (done) {
       const request = { status: 'CALLED' };
       requestStub.resolves(tickets);
@@ -469,6 +496,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on caller (passed as a number)', function (done) {
       const request = { caller: 111 };
       requestStub.onCall(0).resolves(tickets);
@@ -486,6 +514,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on caller (passed as a User)', function (done) {
       const request = { caller: { id: 111 } };
       requestStub.onCall(0).resolves(tickets);
@@ -503,6 +532,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on min created time (ISO8601)', function (done) {
       const request = { minCreated: '2017-09-02T12:48:10Z' };
       requestStub.onCall(0).resolves(tickets);
@@ -522,6 +552,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on min created time (Unix)', function (done) {
       const request = { minCreated: 1507809281 };
       requestStub.onCall(0).resolves(tickets);
@@ -539,6 +570,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on max created time (ISO8601)', function (done) {
       const request = { maxCreated: '2017-09-02T12:48:10Z' };
       requestStub.onCall(0).resolves(tickets);
@@ -558,6 +590,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on max created time (Unix)', function (done) {
       const request = { maxCreated: 1507809281 };
       requestStub.onCall(0).resolves(tickets);
@@ -575,6 +608,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on min called time (ISO8601)', function (done) {
       const request = { minCalled: '2017-09-02T12:48:10Z' };
       requestStub.onCall(0).resolves(tickets);
@@ -594,6 +628,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on min called time (Unix)', function (done) {
       const request = { minCalled: 1507809281 };
       requestStub.onCall(0).resolves(tickets);
@@ -611,6 +646,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on max called time (ISO8601)', function (done) {
       const request = { maxCalled: '2017-09-02T12:48:10Z' };
       requestStub.onCall(0).resolves(tickets);
@@ -630,6 +666,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('searches based on max called time (Unix)', function (done) {
       const request = { maxCalled: 1507809281 };
       requestStub.onCall(0).resolves(tickets);
@@ -647,6 +684,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('does not allow a limit', function (done) {
       const request = { line: [1234], limit: 5 };
       requestStub.onCall(0).resolves(tickets);
@@ -667,6 +705,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('does not allow ordering', function (done) {
       const request = { line: [1234], order: 'id ASC' };
       requestStub.onCall(0).resolves(tickets);
@@ -687,6 +726,7 @@ describe('Ticket service', function () {
         },
       );
     });
+
     it('combines multiple searched parameters successfully', function (done) {
       const request: any = {
         line: [123, 234, 345],
@@ -710,7 +750,7 @@ describe('Ticket service', function () {
         },
       );
     });
-    // ---
+
     it('its return value is a Number', function (done) {
       requestStub.onCall(0).resolves({ count: 3 });
       TicketService.count({ line: [1234] }).then((response) => {
@@ -719,23 +759,28 @@ describe('Ticket service', function () {
       });
     });
   });
+
   describe('create()', function () {
     const createRequestBody: any = {
       firstName: 'John',
       lastName: 'Smith',
     };
+
     const createResponseBody: any = {
       id: '12345',
     };
+
     beforeEach(function () {
       requestStub.resolves(createResponseBody);
     });
+
     it('calls the right URL when the line is specified as number', function (done) {
       TicketService.create(11111, createRequestBody).then(() => {
         expect(requestStub.calledWith('lines/11111/ticket', createRequestBody));
         done();
       });
     });
+
     it('calls the right URL when the line is specified as Line', function (done) {
       const line = { id: 11111 };
       TicketService.create(line.id, createRequestBody).then(() => {
@@ -743,18 +788,22 @@ describe('Ticket service', function () {
         done();
       });
     });
+
     it('resolves to a Ticket object', function (done) {
       TicketService.create(11111, createRequestBody).then((response) => {
         expect(response.id).toBe(12345);
         done();
       });
     });
+
     it('throws when line ID is missing', function () {
       expect(() => (TicketService.create as any)(undefined, {})).toThrow();
     });
+
     it('throws when line is a Qminder.Line with undefined ID', function () {
       expect(() => (TicketService.create as any)({} as any)).toThrow();
     });
+
     it('Sends the extras as a JSON array', function () {
       const ticket: any = {
         firstName: 'Jon',
@@ -774,28 +823,32 @@ describe('Ticket service', function () {
         requestStub.calledWith(
           'lines/1/ticket',
           sinon.match({
-            extra: JSON.stringify(ticket.extra),
+            body: {
+              extra: JSON.stringify(ticket.extra),
+            },
           }),
         ),
       ).toBeTruthy();
     });
+
     it('Does not send undefined keys', function () {
       TicketService.create(1, {} as any);
       expect(
-        requestStub.calledWithExactly(
-          'lines/1/ticket',
-          sinon.match({
+        requestStub.calledWithExactly('lines/1/ticket', {
+          body: {
             firstName: undefined,
             lastName: undefined,
             extra: undefined,
             email: undefined,
-          }),
-        ),
+          },
+          method: 'POST',
+        }),
       ).toBeFalsy();
       expect(
-        requestStub.calledWith('lines/1/ticket', sinon.match({})),
+        requestStub.calledWith('lines/1/ticket', sinon.match({ body: {} })),
       ).toBeTruthy();
     });
+
     it('sends last name if it is not null', function () {
       const ticket: any = {
         firstName: 'Jane',
@@ -806,10 +859,11 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'lines/1/ticket',
-          sinon.match.has('lastName', 'Smith'),
+          sinon.match({ body: { lastName: 'Smith', firstName: 'Jane' } }),
         ),
       ).toBeTruthy();
     });
+
     it('does not send last name if it is null', function () {
       const ticket: any = {
         firstName: 'Jane',
@@ -825,6 +879,7 @@ describe('Ticket service', function () {
         ),
       ).toBeTruthy();
     });
+
     it('sends email address if it is defined', function () {
       const ticketWithEmail: any = {
         firstName: 'Jane',
@@ -833,9 +888,13 @@ describe('Ticket service', function () {
       };
       TicketService.create(1, ticketWithEmail);
       expect(
-        requestStub.calledWith('lines/1/ticket', sinon.match(ticketWithEmail)),
+        requestStub.calledWith(
+          'lines/1/ticket',
+          sinon.match({ body: ticketWithEmail }),
+        ),
       ).toBeTruthy();
     });
+
     it('does not send email address if it is not defined', function () {
       const ticketWithoutEmail: any = {
         firstName: 'Jane',
@@ -845,18 +904,21 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'lines/1/ticket',
-          sinon.match(ticketWithoutEmail),
+          sinon.match({ body: ticketWithoutEmail }),
         ),
       ).toBeTruthy();
       expect(
         requestStub.calledWith(
           'lines/1/ticket',
           sinon.match({
-            email: sinon.match.defined,
+            body: {
+              email: sinon.match.defined,
+            },
           }),
         ),
       ).toBeFalsy();
     });
+
     it('sends source if it is defined', function () {
       const ticketWithSource: any = {
         firstName: 'Jane',
@@ -865,9 +927,13 @@ describe('Ticket service', function () {
       };
       TicketService.create(1, ticketWithSource);
       expect(
-        requestStub.calledWith('lines/1/ticket', sinon.match(ticketWithSource)),
+        requestStub.calledWith(
+          'lines/1/ticket',
+          sinon.match({ body: ticketWithSource }),
+        ),
       ).toBeTruthy();
     });
+
     it('does not send source if it is not defined', function () {
       const ticketWithoutSource: any = {
         firstName: 'Jane',
@@ -877,43 +943,50 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'lines/1/ticket',
-          sinon.match(ticketWithoutSource),
+          sinon.match({ body: ticketWithoutSource }),
         ),
       ).toBeTruthy();
       expect(
         requestStub.calledWith(
           'lines/1/ticket',
           sinon.match({
-            source: sinon.match.defined,
+            body: {
+              source: sinon.match.defined,
+            },
           }),
         ),
       ).toBeFalsy();
     });
+
     it('does not send Idempotency-Key if not provided', function () {
       const ticket: any = { firstName: 'Joe', lastName: 'Santana' };
       TicketService.create(1, ticket);
       expect(
         requestStub.calledWith(
           'lines/1/ticket',
-          sinon.match(ticket),
-          'POST',
-          undefined,
+          sinon.match({ body: ticket, method: 'POST' }),
         ),
       ).toBeTruthy();
     });
+
     it('sends Idempotency-Key if provided', function () {
       const ticket: any = { firstName: 'Joe', lastName: 'Santana' };
       TicketService.create(1, ticket, '9e3a333e');
       expect(
         requestStub.calledWith(
           'lines/1/ticket',
-          sinon.match(ticket),
-          'POST',
-          '9e3a333e',
+          sinon.match({
+            method: 'POST',
+            body: ticket,
+            headers: {
+              'Idempotency-Key': '9e3a333e',
+            },
+          }),
         ),
       ).toBeTruthy();
     });
   });
+
   describe('details()', function () {
     const detailsResponseBody = {
       id: '12345',
@@ -925,12 +998,14 @@ describe('Ticket service', function () {
     beforeEach(function () {
       requestStub.resolves(detailsResponseBody);
     });
+
     it('calls the right URL when ticket ID is passed in as number', function (done) {
       TicketService.details(12345).then(() => {
         expect(requestStub.calledWith('tickets/12345')).toBeTruthy();
         done();
       });
     });
+
     it('calls the right URL when ticket is passed in as a Ticket', function (done) {
       const ticket = { id: 12345 };
       TicketService.details(ticket).then(() => {
@@ -938,22 +1013,27 @@ describe('Ticket service', function () {
         done();
       });
     });
+
     it('resolves to a Ticket object', function (done) {
       TicketService.details(12345).then((response) => {
         expect(response).toEqual(expect.objectContaining(detailsResponseBody));
         done();
       });
     });
+
     it('throws when ticket is missing', function () {
       expect(() => TicketService.details(undefined)).toThrow();
     });
+
     it('throws when ticket is invalid', function () {
       // eslint-disable-next-line no-empty-function
       expect(() => (TicketService.details as any)(function () {})).toThrow();
     });
+
     it('throws when ticket is a Ticket object but id is undefined', function () {
       expect(() => TicketService.details({} as any)).toThrow();
     });
+
     it('does not set the email key when response does not include email', function () {
       const responseBody = { ...detailsResponseBody };
       delete responseBody.email;
@@ -967,6 +1047,7 @@ describe('Ticket service', function () {
       });
     });
   });
+
   describe('edit()', function () {
     const editedFields: any = {
       line: 11111,
@@ -974,32 +1055,36 @@ describe('Ticket service', function () {
       lastName: 'Smithicus',
       email: 'jsmithicus@example.com',
     };
+
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL when ticket is passed as ID', function (done) {
       TicketService.edit(12345, editedFields).then((response) => {
         console.log(requestStub.firstCall.args);
         expect(
-          requestStub.calledWith('tickets/12345/edit', editedFields),
+          requestStub.calledWith('tickets/12345/edit', { body: editedFields }),
         ).toBeTruthy();
         expect(response).toBe('success');
         done();
       });
     });
+
     it('calls the right URL when ticket is passed as a Ticket object', function (done) {
       const ticket = { id: 12345 };
       TicketService.edit(ticket, editedFields).then((response) => {
         console.log(requestStub.firstCall.args);
         expect(
-          requestStub.calledWith('tickets/12345/edit', editedFields),
+          requestStub.calledWith('tickets/12345/edit', { body: editedFields }),
         ).toBeTruthy();
         expect(response).toBe('success');
         done();
       });
     });
+
     it('throws when ticket is missing', function () {
       expect(function () {
         (TicketService.edit as any)(undefined);
@@ -1008,14 +1093,17 @@ describe('Ticket service', function () {
         (TicketService.edit as any)(undefined, { lastName: 'wow' });
       }).toThrow();
     });
+
     it("throws when there's no changes", function () {
       expect(function () {
         TicketService.edit({ id: 12345 }, undefined);
       }).toThrow();
     });
+
     it('throws when ticket is invalid', function () {
       expect(() => (TicketService.edit as any)('wheeee')).toThrow();
     });
+
     it('throws when ticket is a Ticket object but id is undefined', function () {
       expect(() => (TicketService.edit as any)({} as any)).toThrow();
     });
@@ -1025,7 +1113,7 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'tickets/12345/edit',
-          sinon.match({ firstName: '' }),
+          sinon.match({ body: { firstName: '' } }),
         ),
       ).toBeTruthy();
     });
@@ -1035,7 +1123,7 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'tickets/12345/edit',
-          sinon.match({ lastName: '' }),
+          sinon.match({ body: { lastName: '' } }),
         ),
       ).toBeTruthy();
     });
@@ -1045,7 +1133,7 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'tickets/12345/edit',
-          sinon.match({ email: '' }),
+          sinon.match({ body: { email: '' } }),
         ),
       ).toBeTruthy();
     });
@@ -1055,7 +1143,7 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'tickets/12345/edit',
-          sinon.match({ firstName: null }),
+          sinon.match({ body: { firstName: null } }),
         ),
       ).toBeTruthy();
     });
@@ -1065,7 +1153,7 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'tickets/12345/edit',
-          sinon.match({ lastName: null }),
+          sinon.match({ body: { lastName: null } }),
         ),
       ).toBeTruthy();
     });
@@ -1075,7 +1163,7 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'tickets/12345/edit',
-          sinon.match({ phoneNumber: null }),
+          sinon.match({ body: { phoneNumber: null } }),
         ),
       ).toBeTruthy();
     });
@@ -1085,7 +1173,7 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'tickets/12345/edit',
-          sinon.match({ email: null }),
+          sinon.match({ body: { email: null } }),
         ),
       ).toBeTruthy();
     });
@@ -1096,7 +1184,7 @@ describe('Ticket service', function () {
       expect(
         requestStub.calledWith(
           'tickets/12345/edit',
-          sinon.match({ email: null, user: '14141' }),
+          sinon.match({ body: { email: null, user: '14141' } }),
         ),
       ).toBeTruthy();
     });
@@ -1118,7 +1206,9 @@ describe('Ticket service', function () {
         requestStub.calledWith(
           'tickets/12345/edit',
           sinon.match({
-            extra: JSON.stringify(changes.extra),
+            body: {
+              extra: JSON.stringify(changes.extra),
+            },
           }),
         ),
       ).toBeTruthy();
@@ -1129,31 +1219,42 @@ describe('Ticket service', function () {
     beforeEach(function () {
       requestStub.resolves(JON_SNOW);
     });
+
     it('calls the right URL with ticket ID as number', function (done) {
       TicketService.call(12345).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', undefined, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: undefined,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('calls the right URL with a Ticket', function (done) {
       TicketService.call({ id: 12345 }).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', undefined, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: undefined,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('Returns a ticket with all fields present', function (done) {
       TicketService.call(12345).then((ticket) => {
         expect(ticket).toEqual(expect.objectContaining(JON_SNOW));
         done();
       });
     });
+
     it('throws when the ticket ID is missing', function () {
       expect(() => (TicketService.call as any)()).toThrow();
     });
+
     it('throws when the Ticket has no ID', function () {
       expect(() => TicketService.call({} as any)).toThrow();
     });
@@ -1162,20 +1263,28 @@ describe('Ticket service', function () {
       const request = sinon.match({ user: '686' });
       TicketService.call(12345, 686).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', request, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('calls the right URL with ticket and User', function (done) {
       const request = sinon.match({ user: '686' });
       TicketService.call(12345, { id: 686 }).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', request, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws when the User has no ID', function () {
       expect(() => TicketService.call(12345, {} as any)).toThrow();
     });
@@ -1184,21 +1293,29 @@ describe('Ticket service', function () {
       const request = sinon.match({ user: '686' });
       TicketService.call(12345, 686).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', request, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('calls the right URL with ticket, user and Desk', function (done) {
       const request = sinon.match({ user: '666', desk: '3' });
       const desk = { id: 3 };
       TicketService.call(12345, 666, desk).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', request, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws when the Desk has no ID', function () {
       expect(() => TicketService.call(12345, 1234, {} as any)).toThrow();
     });
@@ -1207,11 +1324,15 @@ describe('Ticket service', function () {
       const request = sinon.match({ user: '2', desk: '3' });
       TicketService.call(1, 2, 3).then(() => {
         expect(
-          requestStub.calledWith('tickets/1/call', request, 'POST'),
+          requestStub.calledWith('tickets/1/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('calls the right URL with ticket, user, desk all objects', function (done) {
       const request = sinon.match({ user: '2', desk: '3' });
       const ticket = { id: 1 };
@@ -1219,45 +1340,59 @@ describe('Ticket service', function () {
       const desk = { id: 3 };
       TicketService.call(ticket, user, desk).then(() => {
         expect(
-          requestStub.calledWith('tickets/1/call', request, 'POST'),
+          requestStub.calledWith('tickets/1/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('includes keepActiveTicketsOpen if set to true', function (done) {
       const request = sinon.match({ keepActiveTicketsOpen: true });
       TicketService.call(12345, null, null, true).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', request, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('includes keepActiveTicketsOpen if set to false', function (done) {
       const request = sinon.match({ keepActiveTicketsOpen: false });
       TicketService.call(12345, null, null, false).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', request, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('sends no request body if all params undefined', function (done) {
       TicketService.call(12345, null, null).then(() => {
-        expect(requestStub.firstCall.args[1]).toBeUndefined();
+        expect(requestStub.firstCall.args[1].body).toBeUndefined();
         done();
       });
     });
+
     it('does not send keepActiveTicketsOpen if all params undefined', function (done) {
       TicketService.call(12345, 12, 34).then(() => {
-        expect(requestStub.firstCall.args[1].user).toBe('12');
-        expect(requestStub.firstCall.args[1].desk).toBe('34');
+        expect(requestStub.firstCall.args[1].body.user).toBe('12');
+        expect(requestStub.firstCall.args[1].body.desk).toBe('34');
         expect(
-          requestStub.firstCall.args[1].keepActiveTicketsOpen,
+          requestStub.firstCall.args[1].body.keepActiveTicketsOpen,
         ).toBeUndefined();
         done();
       });
     });
+
     it('includes keepActiveTicketsOpen with other params in request', function (done) {
       const request = sinon.match({
         user: '12',
@@ -1266,174 +1401,207 @@ describe('Ticket service', function () {
       });
       TicketService.call(12345, 12, 34, false).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/call', request, 'POST'),
+          requestStub.calledWith('tickets/12345/call', {
+            body: request,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
   });
+
   describe('recall()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with GET', function (done) {
       TicketService.recall(12345).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/recall', undefined, 'POST'),
+          requestStub.calledWith('tickets/12345/recall', { method: 'POST' }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.recall as any)()).toThrow();
     });
   });
+
   describe('markServed()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with GET', function (done) {
       TicketService.markServed(12345).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/markserved', undefined, 'POST'),
+          requestStub.calledWith('tickets/12345/markserved', {
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.markServed as any)()).toThrow();
     });
   });
+
   describe('markNoShow()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with GET', function (done) {
       TicketService.markNoShow(12345).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/marknoshow', undefined, 'POST'),
+          requestStub.calledWith('tickets/12345/marknoshow', {
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.markNoShow as any)()).toThrow();
     });
   });
+
   describe('cancel()', function () {
     beforeEach(function () {
       requestStub.resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with GET', function (done) {
       const matcher = sinon.match({ user: '14141' });
       TicketService.cancel(12345, 14141).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/cancel', matcher, 'POST'),
+          requestStub.calledWith('tickets/12345/cancel', {
+            body: matcher,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.cancel as any)()).toThrow();
     });
+
     it('throws an error when the ticket parameter is passed a random object', function () {
       expect(() => TicketService.cancel({ test: 5 } as any, 14141)).toThrow();
     });
+
     it('works when the ticket parameter is a Qminder.Ticket', function () {
       const t = { id: 12345 };
       expect(() => TicketService.cancel(t, 14141)).not.toThrow();
       TicketService.cancel(t, 14141);
       expect(
-        requestStub.calledWith(
-          'tickets/12345/cancel',
-          { user: '14141' },
-          'POST',
-        ),
+        requestStub.calledWith('tickets/12345/cancel', {
+          body: { user: '14141' },
+          method: 'POST',
+        }),
       ).toBeTruthy();
     });
+
     it('works when the user parameter is a Qminder.User', function () {
       const u = { id: 14141 };
       expect(() => TicketService.cancel(12345, u)).not.toThrow();
       TicketService.cancel(12345, u);
       expect(
-        requestStub.calledWith(
-          'tickets/12345/cancel',
-          { user: '14141' },
-          'POST',
-        ),
+        requestStub.calledWith('tickets/12345/cancel', {
+          body: { user: '14141' },
+          method: 'POST',
+        }),
       ).toBeTruthy();
     });
   });
+
   describe('returnToQueue()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with GET', function (done) {
       TicketService.returnToQueue(12345, 111, 'FIRST').then(() => {
         expect(
           requestStub.calledWith(
             'tickets/12345/returntoqueue?position=FIRST&user=111',
-            undefined,
-            'POST',
+            { method: 'POST' },
           ),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.returnToQueue as any)()).toThrow();
     });
+
     it('throws an error when the user is missing', function () {
       expect(() => (TicketService.returnToQueue as any)(12345)).toThrow();
     });
+
     it('does not throw an error when the user is a number', function () {
       expect(() =>
         TicketService.returnToQueue(12345, 1234, 'FIRST'),
       ).not.toThrow();
     });
+
     it('throws an error when the position is missing', function () {
       expect(() => (TicketService.returnToQueue as any)(12345, 1234)).toThrow();
     });
   });
+
   describe('addLabel()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with POST and parameters', function (done) {
       TicketService.addLabel(12345, 'LABEL', 41414).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/labels/add',
-            { value: 'LABEL', user: '41414' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/labels/add', {
+            body: { value: 'LABEL', user: '41414' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.addLabel as any)()).toThrow();
     });
+
     it('throws an error when the label text is missing', function () {
       expect(() => (TicketService.addLabel as any)(12345)).toThrow();
     });
+
     it('does not throw an error when the user is missing (#147)', function () {
       expect(() =>
         (TicketService.addLabel as any)(12345, 'LABEL'),
       ).not.toThrow();
     });
+
     it('does not throw an error when the user is a Qminder.User', function () {
       expect(() =>
         TicketService.addLabel(12345, 'LABEL', { id: 41414 }),
@@ -1444,149 +1612,163 @@ describe('Ticket service', function () {
     it('calls the right URL with POST and parameters, without user ID (#147)', function (done) {
       TicketService.addLabel(12345, 'LABEL').then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/labels/add',
-            { value: 'LABEL' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/labels/add', {
+            body: { value: 'LABEL' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('does not throw an error when the user is null (#147)', function () {
       expect(() => TicketService.addLabel(12345, 'LABEL', null)).not.toThrow();
     });
+
     it('does not throw an error when the user is a number', function () {
       expect(() => TicketService.addLabel(12345, 'LABEL', 1234)).not.toThrow();
     });
   });
+
   describe('setLabels()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with PUT and parameters', function (done) {
       TicketService.setLabels(12345, ['Label 1', 'Label 2']).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/labels',
-            JSON.stringify({ labels: ['Label 1', 'Label 2'] }),
-            'PUT',
-          ),
+          requestStub.calledWith('tickets/12345/labels', {
+            body: JSON.stringify({ labels: ['Label 1', 'Label 2'] }),
+            method: 'PUT',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.setLabels as any)()).toThrow();
     });
+
     it('throws an error when the labels are missing', function () {
       expect(() => (TicketService.setLabels as any)(12345)).toThrow();
     });
   });
+
   describe('removeLabel()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with POST and parameters', function (done) {
       TicketService.removeLabel(12345, 'LABEL', 41414).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/labels/remove',
-            { value: 'LABEL', user: '41414' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/labels/remove', {
+            body: { value: 'LABEL', user: '41414' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.removeLabel as any)()).toThrow();
     });
+
     it('throws an error when the label text is missing', function () {
       expect(() => (TicketService.removeLabel as any)(12345)).toThrow();
     });
+
     it('throws an error when the user is missing', function () {
       expect(() =>
         (TicketService.removeLabel as any)(12345, 'LABEL'),
       ).toThrow();
     });
+
     it('does not throw an error when the user is a number', function () {
       expect(() =>
         (TicketService.removeLabel as any)(12345, 'LABEL', 1234),
       ).not.toThrow();
     });
   });
+
   describe('unassign()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with POST and parameters', function (done) {
       TicketService.unassign(63020420, 7500).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/63020420/unassign',
-            { user: '7500' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/63020420/unassign', {
+            body: { user: '7500' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.unassign as any)()).toThrow();
     });
+
     it('throws an error when the assigner is missing', function () {
       expect(() => (TicketService.unassign as any)(63020424)).toThrow();
     });
+
     it('works with User object passed as User parameter', function (done) {
       const unassigner = { id: 4100 };
       TicketService.unassign(63020421, unassigner).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/63020421/unassign',
-            { user: '4100' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/63020421/unassign', {
+            body: { user: '4100' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('works with Ticket object passed as ticket parameter', function (done) {
       const ticket = { id: 60403009 };
       TicketService.unassign(ticket, 4142).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/60403009/unassign',
-            { user: '4142' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/60403009/unassign', {
+            body: { user: '4142' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('works with Ticket & User object passed as parameters', function (done) {
       const unassigner = { id: 4100 };
       const ticket = { id: 59430 };
       TicketService.unassign(ticket, unassigner).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/59430/unassign',
-            { user: '4100' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/59430/unassign', {
+            body: { user: '4100' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the unassigner is invalid', function () {
       expect(() => TicketService.unassign(63020422, {} as any)).toThrow();
     });
+
     it('throws an error when the response returns an error', function (done) {
       requestStub.resetBehavior();
       requestStub
@@ -1603,113 +1785,125 @@ describe('Ticket service', function () {
       );
     });
   });
+
   describe('assignToUser()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL with POST and parameters', function (done) {
       TicketService.assignToUser(12345, 41413, 41414).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/assign',
-            { assigner: '41413', assignee: '41414' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/assign', {
+            body: { assigner: '41413', assignee: '41414' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('throws an error when the ticket ID is missing', function () {
       expect(() => (TicketService.assignToUser as any)()).toThrow();
     });
+
     it('throws an error when the assigner is missing', function () {
       expect(() => (TicketService.assignToUser as any)(12345)).toThrow();
     });
   });
+
   describe('reorder()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         result: 'success',
       });
     });
+
     it('calls the right URL for reorder after ticket', function (done) {
       TicketService.reorder(12345, 12346).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/reorder',
-            { after: '12346' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/reorder', {
+            body: { after: '12346' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('works when the ticket is a Ticket object', function (done) {
       const ticket = { id: 12345 };
       TicketService.reorder(ticket, 12346).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/reorder',
-            { after: '12346' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/reorder', {
+            body: { after: '12346' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('works when the afterTicket is a Ticket object', function (done) {
       const afterTicket = { id: 12346 };
       TicketService.reorder(12345, afterTicket).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/reorder',
-            { after: '12346' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/reorder', {
+            body: { after: '12346' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('works when both ticket and afterTicket are Ticket objects', function (done) {
       const ticket = { id: 12345 };
       const afterTicket = { id: 12346 };
       TicketService.reorder(ticket, afterTicket).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/reorder',
-            { after: '12346' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/reorder', {
+            body: { after: '12346' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('calls the right URL when reordering to be first', function (done) {
       TicketService.reorder(12345, null as any).then(() => {
         expect(
-          requestStub.calledWith('tickets/12345/reorder', undefined, 'POST'),
+          requestStub.calledWith('tickets/12345/reorder', {
+            body: undefined,
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
     });
+
     it('omits the after key when reordering to be first (#159)', function (done) {
       TicketService.reorder(12345, null).then(() => {
-        expect(requestStub.firstCall.args[1]).toBeUndefined();
+        expect(requestStub.firstCall.args[1].body).toBeUndefined();
         done();
       });
     });
+
     it('throws when the ticket ID is missing', function () {
       expect(() => (TicketService.reorder as any)()).toThrow();
     });
   });
+
   describe('getEstimatedTimeOfService()', function () {
     beforeEach(function () {
       requestStub.onCall(0).resolves({
         estimatedTimeOfService: Date.now() / 1000,
       });
     });
+
     it('calls the right URL for getting estimated time', function (done) {
       TicketService.getEstimatedTimeOfService(12345).then(() => {
         expect(
@@ -1718,12 +1912,14 @@ describe('Ticket service', function () {
         done();
       });
     });
+
     it('throws when the ticket ID is missing', function () {
       expect(() =>
         (TicketService.getEstimatedTimeOfService as any)(),
       ).toThrow();
     });
   });
+
   describe('getMessages()', function () {
     beforeEach(function () {
       requestStub.resolves({
@@ -1748,12 +1944,14 @@ describe('Ticket service', function () {
         ],
       });
     });
+
     it('calls the right URL for getting messages', function (done) {
       TicketService.getMessages(12345).then(() => {
         expect(requestStub.calledWith('tickets/12345/messages')).toBeTruthy();
         done();
       });
     });
+
     it('resolves with the messages from response.messages', function (done) {
       TicketService.getMessages(12345).then((data) => {
         expect(data instanceof Array).toBeTruthy();
@@ -1766,6 +1964,7 @@ describe('Ticket service', function () {
         done();
       });
     });
+
     it('does not try to read response.data (#154)', function (done) {
       requestStub.resolves({
         data: [{ body: 'Wrong object!' }],
@@ -1778,10 +1977,12 @@ describe('Ticket service', function () {
         done();
       });
     });
+
     it('throws when the ticket ID is missing', function () {
       expect(() => (TicketService.getMessages as any)()).toThrow();
     });
   });
+
   describe('sendMessage()', function () {
     beforeEach(function () {
       requestStub.resolves({
@@ -1792,11 +1993,10 @@ describe('Ticket service', function () {
     it('calls the right URL for sending a message with User object', function (done) {
       TicketService.sendMessage(12345, 'Hello!', { id: 41414 }).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/messages',
-            { message: 'Hello!', user: '41414' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/messages', {
+            body: { message: 'Hello!', user: '41414' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });
@@ -1805,11 +2005,10 @@ describe('Ticket service', function () {
     it('calls the right URL for sending a message with user ID', function (done) {
       TicketService.sendMessage(12345, 'Hello!', 41414).then(() => {
         expect(
-          requestStub.calledWith(
-            'tickets/12345/messages',
-            { message: 'Hello!', user: '41414' },
-            'POST',
-          ),
+          requestStub.calledWith('tickets/12345/messages', {
+            body: { message: 'Hello!', user: '41414' },
+            method: 'POST',
+          }),
         ).toBeTruthy();
         done();
       });

--- a/src/lib/services/ticket/ticket.ts
+++ b/src/lib/services/ticket/ticket.ts
@@ -349,13 +349,15 @@ export function create(
   }
 
   const requestParams: TicketCreationRequest = { ...converted };
+  const headers = idempotencyKey && {
+    'Idempotency-Key': `${idempotencyKey}`,
+  };
 
-  return ApiBase.request(
-    `lines/${lineId}/ticket`,
-    requestParams,
-    'POST',
-    idempotencyKey,
-  ).then((response: TicketCreationResponse) => {
+  return ApiBase.request(`lines/${lineId}/ticket`, {
+    method: 'POST',
+    body: requestParams,
+    headers: headers,
+  }).then((response: TicketCreationResponse) => {
     const ticketId = parseInt(`${response.id}`, 10);
     const reply: TicketCreationResponse = { id: ticketId };
     return reply;
@@ -391,7 +393,7 @@ export function edit(
 
   const request: TicketEditingRequest = intermediate;
 
-  return ApiBase.request(`tickets/${ticketId}/edit`, request).then(
+  return ApiBase.request(`tickets/${ticketId}/edit`, { body: request }).then(
     (response: { result: 'success' }) => response.result,
   );
 }
@@ -427,7 +429,10 @@ export function call(
     request = undefined;
   }
 
-  return ApiBase.request(`tickets/${ticketId}/call`, request, 'POST');
+  return ApiBase.request(`tickets/${ticketId}/call`, {
+    body: request,
+    method: 'POST',
+  });
 }
 
 export function recall(ticket: IdOrObject<Ticket>): Promise<'success'> {
@@ -436,7 +441,7 @@ export function recall(ticket: IdOrObject<Ticket>): Promise<'success'> {
   if (!ticketId || typeof ticketId !== 'string') {
     throw new Error(ERROR_NO_TICKET_ID);
   }
-  return ApiBase.request(`tickets/${ticketId}/recall`, undefined, 'POST').then(
+  return ApiBase.request(`tickets/${ticketId}/recall`, { method: 'POST' }).then(
     (response: { result: 'success' }) => response.result,
   );
 }
@@ -448,11 +453,9 @@ export function markServed(ticket: IdOrObject<Ticket>): Promise<'success'> {
     throw new Error(ERROR_NO_TICKET_ID);
   }
 
-  return ApiBase.request(
-    `tickets/${ticketId}/markserved`,
-    undefined,
-    'POST',
-  ).then((response: { result: 'success' }) => response.result);
+  return ApiBase.request(`tickets/${ticketId}/markserved`, {
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function markNoShow(ticket: IdOrObject<Ticket>): Promise<'success'> {
@@ -461,11 +464,9 @@ export function markNoShow(ticket: IdOrObject<Ticket>): Promise<'success'> {
   if (!ticketId || typeof ticketId !== 'string') {
     throw new Error(ERROR_NO_TICKET_ID);
   }
-  return ApiBase.request(
-    `tickets/${ticketId}/marknoshow`,
-    undefined,
-    'POST',
-  ).then((response: { result: 'success' }) => response.result);
+  return ApiBase.request(`tickets/${ticketId}/marknoshow`, {
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function cancel(
@@ -482,11 +483,10 @@ export function cancel(
     throw new Error(ERROR_NO_USER);
   }
 
-  return ApiBase.request(
-    `tickets/${ticketId}/cancel`,
-    { user: userId },
-    'POST',
-  ).then((response: { result: 'success' }) => response.result);
+  return ApiBase.request(`tickets/${ticketId}/cancel`, {
+    body: { user: userId },
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function returnToQueue(
@@ -513,11 +513,9 @@ export function returnToQueue(
     position: `${position}`,
     user: userId,
   }).toString();
-  return ApiBase.request(
-    `tickets/${ticketId}/returntoqueue?${query}`,
-    undefined,
-    'POST',
-  ).then((response: { result: 'success' }) => response.result);
+  return ApiBase.request(`tickets/${ticketId}/returntoqueue?${query}`, {
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function addLabel(
@@ -544,9 +542,10 @@ export function addLabel(
     body.user = userId;
   }
 
-  return ApiBase.request(`tickets/${ticketId}/labels/add`, body, 'POST').then(
-    (response: { result: 'success' | 'no action' }) => response.result,
-  );
+  return ApiBase.request(`tickets/${ticketId}/labels/add`, {
+    body: body,
+    method: 'POST',
+  }).then((response: { result: 'success' | 'no action' }) => response.result);
 }
 
 export function setLabels(
@@ -565,11 +564,10 @@ export function setLabels(
 
   const body: { labels: Array<string> } = { labels };
 
-  return ApiBase.request(
-    `tickets/${ticketId}/labels`,
-    JSON.stringify(body),
-    'PUT',
-  ).then((response: { result: 'success' }) => response.result);
+  return ApiBase.request(`tickets/${ticketId}/labels`, {
+    body: JSON.stringify(body),
+    method: 'PUT',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function removeLabel(
@@ -597,11 +595,10 @@ export function removeLabel(
     user: userId,
   };
 
-  return ApiBase.request(
-    `tickets/${ticketId}/labels/remove`,
-    body,
-    'POST',
-  ).then((response: { result: 'success' }) => response.result);
+  return ApiBase.request(`tickets/${ticketId}/labels/remove`, {
+    body: body,
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function assignToUser(
@@ -629,9 +626,10 @@ export function assignToUser(
     assigner: assignerId,
     assignee: assigneeId,
   };
-  return ApiBase.request(`tickets/${ticketId}/assign`, body, 'POST').then(
-    (response: { result: 'success' }) => response.result,
-  );
+  return ApiBase.request(`tickets/${ticketId}/assign`, {
+    body: body,
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function unassign(
@@ -651,11 +649,10 @@ export function unassign(
     );
   }
 
-  return ApiBase.request(
-    `tickets/${ticketId}/unassign`,
-    { user: unassignerId },
-    'POST',
-  ).then((response: { result: 'success' }) => response.result);
+  return ApiBase.request(`tickets/${ticketId}/unassign`, {
+    body: { user: unassignerId },
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function reorder(
@@ -678,9 +675,10 @@ export function reorder(
     };
   }
 
-  return ApiBase.request(`tickets/${ticketId}/reorder`, postData, 'POST').then(
-    (response: { result: 'success' }) => response.result,
-  );
+  return ApiBase.request(`tickets/${ticketId}/reorder`, {
+    body: postData,
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function getEstimatedTimeOfService(
@@ -736,9 +734,10 @@ export function sendMessage(
     user: userId,
   };
 
-  return ApiBase.request(`tickets/${ticketId}/messages`, body, 'POST').then(
-    (response: { result: 'success' }) => response.result,
-  );
+  return ApiBase.request(`tickets/${ticketId}/messages`, {
+    body: body,
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }
 
 export function forward(
@@ -771,7 +770,7 @@ export function forward(
     body.user = userId;
   }
 
-  return ApiBase.request(`tickets/${ticketId}/forward`, body);
+  return ApiBase.request(`tickets/${ticketId}/forward`, { body: body });
 }
 
 export function setExternalData(
@@ -804,7 +803,8 @@ export function setExternalData(
     data: JSON.stringify(data),
   };
 
-  return ApiBase.request(`tickets/${ticketId}/external`, payload, 'POST').then(
-    (response: { result: 'success' }) => response.result,
-  );
+  return ApiBase.request(`tickets/${ticketId}/external`, {
+    body: payload,
+    method: 'POST',
+  }).then((response: { result: 'success' }) => response.result);
 }

--- a/src/lib/services/user/user.service.spec.ts
+++ b/src/lib/services/user/user.service.spec.ts
@@ -70,6 +70,7 @@ describe('User service', function () {
         expect(returnedIds[i]).toBe(groundTruth[i]);
       }
     });
+
     it('returns the right email addresses', function () {
       const returned = usersReply.map((user: User) => user.email);
       const groundTruth = USERS.map((user) => user.email);
@@ -78,6 +79,7 @@ describe('User service', function () {
         expect(returned[i]).toBe(groundTruth[i]);
       }
     });
+
     it('returns the right first names', function () {
       const returned = usersReply.map((user: User) => user.firstName);
       const groundTruth = USERS.map((user) => user.firstName);
@@ -86,6 +88,7 @@ describe('User service', function () {
         expect(returned[i]).toBe(groundTruth[i]);
       }
     });
+
     it('returns the right last names', function () {
       const returned = usersReply.map((user: User) => user.lastName);
       const groundTruth = USERS.map((user) => user.lastName);
@@ -94,6 +97,7 @@ describe('User service', function () {
         expect(returned[i]).toBe(groundTruth[i]);
       }
     });
+
     it('returns the right pictures', function () {
       const returned = usersReply
         .map((user: User) => user.picture[0])
@@ -107,6 +111,7 @@ describe('User service', function () {
       }
     });
   });
+
   describe('create()', function () {
     // UserService.create(userdata)
 
@@ -134,22 +139,26 @@ describe('User service', function () {
         requestStub.calledWith(
           'users/',
           sinon.match({
-            roles: JSON.stringify(user.roles),
+            body: {
+              roles: JSON.stringify(user.roles),
+            },
           }),
         ),
       ).toBeTruthy();
     });
   });
+
   describe('details()', function () {
     // UserService.details(userId|userEmail)
   });
+
   describe('setLines()', function () {
     it('Works with a list of Line IDs', function () {
       UserService.setLines(123, [1, 2, 3, 4]);
       expect(
         requestStub.calledWith(
           'users/123/lines',
-          sinon.match(JSON.stringify([1, 2, 3, 4])),
+          sinon.match({ body: JSON.stringify([1, 2, 3, 4]) }),
         ),
       ).toBeTruthy();
     });
@@ -165,7 +174,7 @@ describe('User service', function () {
       expect(
         requestStub.calledWith(
           'users/123/lines',
-          sinon.match(JSON.stringify([1, 2, 3])),
+          sinon.match({ body: JSON.stringify([1, 2, 3]) }),
         ),
       ).toBeTruthy();
     });

--- a/src/lib/services/user/user.ts
+++ b/src/lib/services/user/user.ts
@@ -37,16 +37,15 @@ export function create(
   if (!roles) {
     throw new Error("The user's roles are missing");
   }
-  return ApiBase.request(
-    `users/`,
-    {
+  return ApiBase.request(`users/`, {
+    body: {
       email,
       firstName,
       lastName,
       roles: JSON.stringify(roles),
     },
-    'POST',
-  ) as Promise<User>;
+    method: 'POST',
+  }) as Promise<User>;
 }
 
 export function details(
@@ -66,12 +65,15 @@ export function details(
 export function selectDesk(user: IdOrObject<User>, desk: IdOrObject<Desk>) {
   const userId = extractId(user);
   const deskId = extractId(desk);
-  return ApiBase.request(`users/${userId}/desk`, { desk: deskId }, 'POST');
+  return ApiBase.request(`users/${userId}/desk`, {
+    body: { desk: deskId },
+    method: 'POST',
+  });
 }
 
 export function removeDesk(user: IdOrObject<User>): Promise<SuccessResponse> {
   const userId = extractId(user);
-  return ApiBase.request(`users/${userId}/desk`, undefined, 'DELETE');
+  return ApiBase.request(`users/${userId}/desk`, { method: 'DELETE' });
 }
 
 export function setLines(
@@ -82,9 +84,8 @@ export function setLines(
   const lineIds = lines.map((line: IdOrObject<Line>) =>
     extractIdToNumber(line),
   );
-  return ApiBase.request(
-    `users/${userId}/lines`,
-    JSON.stringify(lineIds),
-    'POST',
-  );
+  return ApiBase.request(`users/${userId}/lines`, {
+    body: JSON.stringify(lineIds),
+    method: 'POST',
+  });
 }

--- a/src/lib/services/webhooks/webhook.service.ts
+++ b/src/lib/services/webhooks/webhook.service.ts
@@ -27,7 +27,8 @@ export const WebhookService = {
    * console.log(webhook.secret); // 'hmacSecretText'
    * // You can use the webhook.secret to check the message validity via HMAC.
    * ```
-   * @param url  the public URL to receive the webhooks, such as https://example.com/webhook
+   * @param url the public URL to receive the webhooks, such as https://example.com/webhook
+   * @param headers the custom HTTP headers to include in the request
    * @returns a Webhook object with the webhook's ID and HMAC secret.
    * @throws {SimpleError}
    * @see Webhook

--- a/src/lib/services/webhooks/webhook.ts
+++ b/src/lib/services/webhooks/webhook.ts
@@ -5,19 +5,22 @@ import { extractId, IdOrObject } from '../../util/id-or-object.js';
 export const ERROR_NO_URL = 'No URL provided';
 
 type CreateWebhookResponse = Webhook;
-
-export function create(url: string): Promise<Webhook> {
+export function create(
+  url: string,
+  headers?: { [key: string]: string },
+): Promise<Webhook> {
   if (!url || typeof url !== 'string') {
     throw new Error(ERROR_NO_URL);
   }
-  return ApiBase.request(
-    `webhooks`,
-    { url },
-    'POST',
-  ) as Promise<CreateWebhookResponse>;
+
+  return ApiBase.request(`webhooks`, {
+    body: { url: url },
+    method: 'POST',
+    ...headers,
+  }) as Promise<CreateWebhookResponse>;
 }
 
 export function remove(webhook: IdOrObject<Webhook>): Promise<void> {
   const id = extractId(webhook);
-  return ApiBase.request(`webhooks/${id}`, undefined, 'DELETE');
+  return ApiBase.request(`webhooks/${id}`, { method: 'DELETE' });
 }

--- a/src/lib/services/webhooks/webhooks.service.spec.ts
+++ b/src/lib/services/webhooks/webhooks.service.spec.ts
@@ -18,21 +18,51 @@ describe('Webhook service', function () {
     beforeEach(function () {
       requestStub.onFirstCall().resolves({ id: 512, secret: 'SECRET!' });
     });
+
     it('throws and does not send a HTTP request if the URL is not provided', function () {
       expect(() => (WebhookService.create as any)()).toThrow();
       expect(requestStub.called).toBeFalsy();
     });
+
     it('throws and does not send a HTTP request if the URL is not a string', function () {
       expect(() =>
         WebhookService.create({ url: 'https://g.co' } as any),
       ).toThrow();
       expect(requestStub.called).toBeFalsy();
     });
+
     it('creates a request with the URL in formdata when provided', function (done) {
       WebhookService.create('https://g.co').then(
         (data) => {
           expect(
-            requestStub.calledWith('webhooks', { url: 'https://g.co' }),
+            requestStub.calledWith('webhooks', {
+              body: { url: 'https://g.co' },
+              method: 'POST',
+            }),
+          ).toBeTruthy();
+          done();
+        },
+        (fail) => {
+          console.error(fail);
+          expect(false).toBe(true);
+          done();
+        },
+      );
+    });
+
+    it('creates a request with headers when provided', function (done) {
+      const headers = {
+        'X-Qminder-Webhook-Type': 'internal',
+      };
+
+      WebhookService.create('https://g.co', headers).then(
+        (data) => {
+          expect(
+            requestStub.calledWith('webhooks', {
+              body: { url: 'https://g.co' },
+              method: 'POST',
+              ...headers,
+            }),
           ).toBeTruthy();
           done();
         },
@@ -49,26 +79,31 @@ describe('Webhook service', function () {
     beforeEach(function () {
       requestStub.onFirstCall().resolves({ status: 'success' });
     });
+
     it('throws and does not send a HTTP request if the ID is not provided', function () {
       expect(() => WebhookService.remove(undefined as any)).toThrow();
       expect(requestStub.called).toBeFalsy();
     });
+
     it('supports string IDs', () => {
       expect(() => WebhookService.remove('fefefe' as any)).not.toThrow();
     });
+
     it('supports webhook objects', () => {
       expect(() =>
         WebhookService.remove({ id: '4c6c94e3-9f26-4b76-8440-d2bc0ebf537c' }),
       ).not.toThrow();
     });
+
     it('throws and does not send a HTTP request if the ID is not provided in the object', function () {
       expect(() => WebhookService.remove({ x: 5 } as any)).toThrow();
       expect(requestStub.called).toBeFalsy();
     });
+
     it('creates a request with the correct URL', function (done) {
       WebhookService.remove(12).then(() => {
         expect(
-          requestStub.calledWith('webhooks/12', undefined, 'DELETE'),
+          requestStub.calledWith('webhooks/12', { method: 'DELETE' }),
         ).toBeTruthy();
         done();
       });


### PR DESCRIPTION
## Description of the change

This PR refactors api-base to allow passing custom headers while creating a new webhook endpoint.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

