### PR TITLE
fix: subscription errors propagated to consumers

### DIFF
--- a/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -27,8 +27,11 @@ export class GraphQLSubscriptionsFixture {
 
   triggerSubscription(
     query: DocumentNode | string = 'subscription { baba }',
+    subscriber:
+      | Partial<Observer<object>>
+      | ((value: object) => void) = () => {},
   ): Subscription {
-    return this.graphqlService.subscribe(query).subscribe(() => {});
+    return this.graphqlService.subscribe(query).subscribe(subscriber);
   }
 
   getGraphqlServiceActiveSubscriptionCount(): number {

--- a/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
+++ b/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
@@ -280,6 +280,10 @@ describe('GraphQL subscriptions', () => {
     });
 
     expect(errorSpy).toHaveBeenCalledWith(ERRORS);
+    // Cleans up as well
+    expect(
+      (fixture.graphqlService as any).subscriptionObserverMap['1'],
+    ).toBeUndefined();
 
     subscription.unsubscribe();
   });


### PR DESCRIPTION
## Description of the change

Ensures that errors sent by the server to the client using GQL_ERROR messages are passed to the consumer of the library. The subscription is assumed to have never opened & internal state is cleaned up.

Connection closures and errors on establishing the connection are logged and otherwise not passed to the consumer, in order to be able to restore connectivity without completing all of the existing Observables.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #580 
Fixes #217 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentoned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
