### PR TITLE
fix: when there are open subscriptions, reconnect even on a close code of 1000

### DIFF
--- a/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -111,6 +111,13 @@ export class GraphQLSubscriptionsFixture {
     });
   }
 
+  async consumeInitMessage() {
+    expect(await this.server.nextMessage).toEqual({
+      type: 'connection_init',
+      payload: null,
+    });
+  }
+
   async consumeAnyMessage() {
     await this.server.nextMessage;
   }

--- a/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -77,9 +77,9 @@ export class GraphQLSubscriptionsFixture {
     });
   }
 
-  async closeWithError(closeCode: number) {
+  async closeWithError(closeCode: number, reason = 'Connection reset by peer') {
     this.server.error({
-      reason: 'Connection reset by peer',
+      reason,
       code: closeCode,
       wasClean: false,
     });

--- a/src/lib/services/graphql/__tests__/graphql-subscriptions-jsdom-only.spec.ts
+++ b/src/lib/services/graphql/__tests__/graphql-subscriptions-jsdom-only.spec.ts
@@ -36,7 +36,7 @@ describe('GraphQL subscriptions', () => {
 
   it('should reconnect based on ping-pong before "onclose" retries connection', async () => {
     (sleepMs as jest.Mock).mockImplementationOnce(() => firstValueFrom(NEVER));
-    fixture.triggerSubscription();
+    const subscription = fixture.triggerSubscription();
     await fixture.handleConnectionInit();
     await fixture.consumeSubscribeMessage();
     await fixture.closeWithError(1006);
@@ -46,6 +46,7 @@ describe('GraphQL subscriptions', () => {
     // reconnect starts
     await fixture.handleConnectionInit();
     await fixture.consumeSubscribeMessage();
+    subscription.unsubscribe();
   });
 
   it('does not initialize multiple connections if all indicators of disconnect are fired at the same time', async () => {
@@ -63,7 +64,7 @@ describe('GraphQL subscriptions', () => {
     );
 
     jest.useFakeTimers(); // setTimeout is also now under jest control
-    fixture.triggerSubscription();
+    const subscription = fixture.triggerSubscription();
     await jest.runAllTimersAsync();
 
     await fixture.handleConnectionInit(); // setInterval
@@ -96,5 +97,6 @@ describe('GraphQL subscriptions', () => {
     // GQL_CONNECTION_ACK not yet received
     expect(openSocketSpy).toHaveBeenCalledTimes(2);
     expect(createSocketConnectionSpy).toHaveBeenCalledTimes(2);
+    subscription.unsubscribe();
   });
 });

--- a/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
+++ b/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
@@ -159,13 +159,12 @@ describe('GraphQL subscriptions', () => {
     await fixture.consumeSubscribeMessage();
 
     await jest.advanceTimersToNextTimerAsync();
-    expect(await fixture.getNextMessage()).toEqual({
-      type: 'ping',
-    });
+    await fixture.consumePingMessage();
 
     await jest.runOnlyPendingTimersAsync();
 
     expect(reconnectSpy).toHaveBeenCalled();
+    await fixture.consumeInitMessage();
     jest.useRealTimers();
     subscription.unsubscribe();
   });

--- a/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
+++ b/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
@@ -169,7 +169,7 @@ describe('GraphQL subscriptions', () => {
     subscription.unsubscribe();
   });
 
-  it('connect, ping timeout, connect, ping timeout, connect', async () => {
+  it('handles multiple consecutive connect/ping/timeout cycles gracefully', async () => {
     const reconnectSpy = jest.spyOn(
       fixture.graphqlService as any,
       'handleConnectionDropWithThisBound',


### PR DESCRIPTION
## Description of the change

If the WebSocket is closed with a close code of 1000, but there are still open listeners, reconnect to the backend.

We think this could be a fix for #601 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Related issues

#601 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

