### PR TITLE
fix: Fixes to ticket creation update

### DIFF
--- a/src/lib/model/fetch.ts
+++ b/src/lib/model/fetch.ts
@@ -1,0 +1,38 @@
+export interface RequestInit {
+  method?: HTTPMethod;
+  headers?: {
+    [key: string]: string;
+  };
+  mode?: 'cors' | 'same-origin' | 'navigate' | 'no-cors';
+  credentials?: 'omit' | 'same-origin' | 'include';
+  cache?:
+    | 'default'
+    | 'force-cache'
+    | 'no-cache'
+    | 'no-store'
+    | 'only-if-cached'
+    | 'reload';
+  body?: string | Blob;
+  referrer?: string;
+  referrerPolicy?:
+    | ''
+    | 'no-referrer'
+    | 'no-referrer-when-downgrade'
+    | 'origin'
+    | 'origin-when-cross-origin'
+    | 'same-origin'
+    | 'strict-origin'
+    | 'strict-origin-when-cross-origin'
+    | 'unsafe-url';
+}
+
+
+export type HTTPMethod =
+  | 'GET'
+  | 'POST'
+  | 'PUT'
+  | 'PATCH'
+  | 'OPTIONS'
+  | 'HEAD'
+  | 'DELETE'
+  | 'CONNECT';

--- a/src/lib/model/fetch.ts
+++ b/src/lib/model/fetch.ts
@@ -26,7 +26,6 @@ export interface RequestInit {
     | 'unsafe-url';
 }
 
-
 export type HTTPMethod =
   | 'GET'
   | 'POST'

--- a/src/lib/model/ticket/ticket-creation-request.ts
+++ b/src/lib/model/ticket/ticket-creation-request.ts
@@ -14,10 +14,10 @@ export interface TicketCreationRequest {
   firstName: string;
   /**
    * Last name (family name) of the visitor.
-   * Can be blank.
+   * Can be blank and undefined.
    * Max length: 50
    */
-  lastName: string;
+  lastName?: string;
   /** Phone number. Regex: /^\+?[0-9]{5,20}$/ */
   phoneNumber?: string;
   /** Email address. Regex: /^\S+@\S+\.\S+$/ */

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -1,22 +1,14 @@
-import fetch from 'cross-fetch';
 import { GraphQLError } from 'graphql';
 import { ComplexError } from '../../model/errors/complex-error.js';
 import { SimpleError } from '../../model/errors/simple-error.js';
 import { UnknownError } from '../../model/errors/unknown-error.js';
 import { GraphqlResponse } from '../../model/graphql-response.js';
+import { RequestInit } from '../../model/fetch.js';
+import fetch from 'cross-fetch';
 
-type HTTPMethod =
-  | 'GET'
-  | 'POST'
-  | 'PUT'
-  | 'PATCH'
-  | 'OPTIONS'
-  | 'HEAD'
-  | 'DELETE'
-  | 'CONNECT';
 
 type RequestInitWithMethodRequired = Pick<
-  CorrectRequestInit,
+  RequestInit,
   'method' | 'headers'
 > & { body?: string | File | object };
 
@@ -32,36 +24,6 @@ export interface GraphqlQuery {
 export interface SuccessResponse {
   status: number;
 }
-
-// NOTE: this is defined because the RequestInit type has issues
-interface CorrectRequestInit {
-  method?: HTTPMethod;
-  headers?: {
-    [key: string]: string;
-  };
-  mode?: 'cors' | 'same-origin' | 'navigate' | 'no-cors';
-  credentials?: 'omit' | 'same-origin' | 'include';
-  cache?:
-    | 'default'
-    | 'force-cache'
-    | 'no-cache'
-    | 'no-store'
-    | 'only-if-cached'
-    | 'reload';
-  body?: string | Blob;
-  referrer?: string;
-  referrerPolicy?:
-    | ''
-    | 'no-referrer'
-    | 'no-referrer-when-downgrade'
-    | 'origin'
-    | 'origin-when-cross-origin'
-    | 'same-origin'
-    | 'strict-origin'
-    | 'strict-origin-when-cross-origin'
-    | 'unsafe-url';
-}
-
 /**
  * Base functionality of the API, such as HTTP requests with the API key.
  *
@@ -81,18 +43,6 @@ export class ApiBase {
    * @private
    */
   private static apiServer = 'api.qminder.com';
-
-  /** The fetch() function to use for API calls.
-   * @private */
-  fetch: Function;
-
-  /**
-   * Constructs a new ApiBase instance.
-   * @constructor
-   */
-  constructor() {
-    this.fetch = fetch;
-  }
 
   /**
    * Set the Qminder API key used for all requests.
@@ -125,7 +75,7 @@ export class ApiBase {
       throw new Error('Please set the API key before making any requests.');
     }
 
-    const init: CorrectRequestInit = {
+    const init: RequestInit = {
       method: options?.method || 'GET',
       mode: 'cors',
       headers: {
@@ -179,7 +129,7 @@ export class ApiBase {
       throw new Error('Please set the API key before making any requests.');
     }
 
-    const init: CorrectRequestInit = {
+    const init: RequestInit = {
       method: 'POST',
       headers: {
         'X-Qminder-REST-API-Key': this.apiKey,

--- a/src/lib/services/api-base/api-base.ts
+++ b/src/lib/services/api-base/api-base.ts
@@ -6,11 +6,9 @@ import { GraphqlResponse } from '../../model/graphql-response.js';
 import { RequestInit } from '../../model/fetch.js';
 import fetch from 'cross-fetch';
 
-
-type RequestInitWithMethodRequired = Pick<
-  RequestInit,
-  'method' | 'headers'
-> & { body?: string | File | object };
+type RequestInitWithMethodRequired = Pick<RequestInit, 'method' | 'headers'> & {
+  body?: string | File | object;
+};
 
 interface GraphqlQueryVariables {
   [key: string]: any;

--- a/src/lib/services/graphql/graphql.service.ts
+++ b/src/lib/services/graphql/graphql.service.ts
@@ -111,7 +111,7 @@ export class GraphqlService {
 
   constructor() {
     this.setServer('api.qminder.com');
-    this.fetch = fetch;
+    this.fetch = fetch.bind(window);
 
     this.subscriptionConnection$ = this.connectionStatus$.pipe(
       startWith(ConnectionStatus.CONNECTING),

--- a/src/lib/services/graphql/graphql.service.ts
+++ b/src/lib/services/graphql/graphql.service.ts
@@ -13,6 +13,7 @@ import { GraphqlResponse } from '../../model/graphql-response.js';
 import { calculateRandomizedExponentialBackoffTime } from '../../util/randomized-exponential-backoff/randomized-exponential-backoff.js';
 import { sleepMs } from '../../util/sleep-ms/sleep-ms.js';
 import { ApiBase, GraphqlQuery } from '../api-base/api-base.js';
+import { RequestInit } from '../../model/fetch.js';
 
 type QueryOrDocument = string | DocumentNode;
 
@@ -88,8 +89,6 @@ export class GraphqlService {
   private apiKey: string;
   private apiServer: string;
 
-  fetch: Function;
-
   private socket: WebSocket = null;
 
   private connectionStatus: ConnectionStatus;
@@ -111,7 +110,6 @@ export class GraphqlService {
 
   constructor() {
     this.setServer('api.qminder.com');
-    this.fetch = fetch.bind(window);
 
     this.subscriptionConnection$ = this.connectionStatus$.pipe(
       startWith(ConnectionStatus.CONNECTING),
@@ -288,7 +286,7 @@ export class GraphqlService {
 
   private async fetchTemporaryApiKey(retryCount = 0): Promise<string> {
     const url = 'graphql/connection-key';
-    const body = {
+    const body: RequestInit = {
       method: 'POST',
       mode: 'cors',
       headers: {
@@ -297,7 +295,7 @@ export class GraphqlService {
     };
 
     try {
-      const response = await this.fetch(
+      const response = await fetch(
         `https://${this.apiServer}/${url}`,
         body,
       );

--- a/src/lib/services/graphql/graphql.service.ts
+++ b/src/lib/services/graphql/graphql.service.ts
@@ -295,10 +295,7 @@ export class GraphqlService {
     };
 
     try {
-      const response = await fetch(
-        `https://${this.apiServer}/${url}`,
-        body,
-      );
+      const response = await fetch(`https://${this.apiServer}/${url}`, body);
       const responseJson = await response.json();
       return responseJson.key;
     } catch (e) {
@@ -307,7 +304,7 @@ export class GraphqlService {
         `[Qminder API]: Failed fetching temporary API key! Retrying in ${
           timeOut / 1000
         } seconds!`,
-        e
+        e,
       );
       return new Promise((resolve) =>
         setTimeout(

--- a/src/lib/services/graphql/graphql.service.ts
+++ b/src/lib/services/graphql/graphql.service.ts
@@ -309,6 +309,7 @@ export class GraphqlService {
         `[Qminder API]: Failed fetching temporary API key! Retrying in ${
           timeOut / 1000
         } seconds!`,
+        e
       );
       return new Promise((resolve) =>
         setTimeout(


### PR DESCRIPTION
Fixes a few issues in the ticket creation update:

* using `this.fetch = fetch;` in graphql.service.ts accidentally reassigns `this` in the fetch body, causing an Illegal invocation error
* lastName can be undefined / not present

## Related issues

#603 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] Changes have been reviewed by at least one other engineer
