### PR TITLE
feat(tickets): Change ticket creation endpoint url

### DIFF
--- a/src/lib/services/ticket/ticket.service.spec.ts
+++ b/src/lib/services/ticket/ticket.service.spec.ts
@@ -789,7 +789,7 @@ describe('Ticket service', function () {
         email: 'foo@bar.com',
       };
       const res = await TicketService.create(request);
-      expect(requestStub).toHaveBeenCalledWith('ticket', {
+      expect(requestStub).toHaveBeenCalledWith('tickets', {
         body: JSON.stringify(request),
         headers: { 'X-Qminder-API-Version': '2020-09-01' },
         method: 'POST',

--- a/src/lib/services/ticket/ticket.ts
+++ b/src/lib/services/ticket/ticket.ts
@@ -324,7 +324,7 @@ export function create(
 ): Promise<TicketCreatedResponse> {
   const body = JSON.stringify(request);
 
-  return ApiBase.request('ticket', {
+  return ApiBase.request('tickets', {
     method: 'POST',
     body,
     headers: {


### PR DESCRIPTION
Reaction to this PR: https://github.com/Qminder/server/pull/20023
Will change the ticket request endpoint from `/ticket/` to `/tickets/`

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] Changes have been reviewed by at least one other engineer
