### PR TITLE
feat(ticket): Add languageCode to TicketCreationRequest

### DIFF
--- a/src/lib/model/ticket/ticket-creation-request.ts
+++ b/src/lib/model/ticket/ticket-creation-request.ts
@@ -22,6 +22,8 @@ export interface TicketCreationRequest {
   phoneNumber?: string;
   /** Email address. Regex: /^\S+@\S+\.\S+$/ */
   email?: string;
+  /** Formatted in ISO 639-1. */
+  languageCode?: string;
   /** Ticket's source. If unspecified, falls back to TicketType.MANUAL */
   source?: TicketType;
   fields?: InputFieldRequest[];


### PR DESCRIPTION
Add languageCode to TicketCreationRequest as:
- defined in `com/qminder/api/controller/tickets/creation/TicketCreationControllerV2.kt:118`
- tested in Dashboard

https://github.com/user-attachments/assets/951f01c5-c35d-43d1-9525-8cfa6477994b

## Related issues



## Checklist

- [ ] Code is covered with tests.
