### PR TITLE
fix: validating fetched temporary API key

### DIFF
--- a/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -23,8 +23,8 @@ export class GraphQLSubscriptionsFixture {
       .mockReturnValue(SERVER_URL);
 
     jest
-        .spyOn(this.graphqlService as any, 'fetchTemporaryApiKey')
-        .mockResolvedValue(DUMMY_API_KEY);
+      .spyOn(this.graphqlService as any, 'fetchTemporaryApiKey')
+      .mockResolvedValue(DUMMY_API_KEY);
   }
 
   triggerSubscription(

--- a/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -14,23 +14,17 @@ const SERVER_URL = `ws://localhost:${PORT}`;
 export class GraphQLSubscriptionsFixture {
   graphqlService = new GraphqlService();
   server: WS;
-  #apiKeyMock: jest.SpyInstance | undefined;
 
   constructor() {
+    this.graphqlService.setKey('permanentkey');
     this.openServer();
     jest
       .spyOn(this.graphqlService as any, 'getServerUrl')
       .mockReturnValue(SERVER_URL);
-  }
 
-  mockApiKeyFetching() {
-    this.#apiKeyMock = jest
-      .spyOn(this.graphqlService as any, 'fetchTemporaryApiKey')
-      .mockResolvedValue(DUMMY_API_KEY);
-  }
-
-  unmockApiKeyFetching() {
-    this.#apiKeyMock?.mockRestore();
+    jest
+        .spyOn(this.graphqlService as any, 'fetchTemporaryApiKey')
+        .mockResolvedValue(DUMMY_API_KEY);
   }
 
   triggerSubscription(

--- a/src/lib/services/graphql/__tests__/graphql-subscriptions-jsdom-only.spec.ts
+++ b/src/lib/services/graphql/__tests__/graphql-subscriptions-jsdom-only.spec.ts
@@ -28,7 +28,6 @@ describe('GraphQL subscriptions', () => {
 
   beforeEach(async () => {
     fixture = new GraphQLSubscriptionsFixture();
-    fixture.mockApiKeyFetching();
   });
 
   afterEach(async () => {

--- a/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
+++ b/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
@@ -29,11 +29,11 @@ describe('GraphQL subscriptions', () => {
   beforeEach(async () => {
     fetchMock.enableMocks();
     fixture = new GraphQLSubscriptionsFixture();
-    fixture.mockApiKeyFetching();
   });
 
   afterEach(async () => {
     await fixture.cleanup();
+    fetchMock.mockClear();
   });
 
   it('sends connection init to start', async () => {
@@ -374,26 +374,6 @@ describe('GraphQL subscriptions', () => {
     ).toBeUndefined();
 
     subscription.unsubscribe();
-  });
-
-  describe('API Key', () => {
-    it('fetches temporary API key', () => {
-      fixture.graphqlService.setKey('initialkey');
-      fixture.unmockApiKeyFetching();
-
-      fetchMock.mockResponseOnce(JSON.stringify({ key: '12345' }));
-      fixture.triggerSubscription();
-
-      expect(fetch).toHaveBeenCalledTimes(1);
-      expect(fetch).toHaveBeenCalledWith(
-        'https://api.qminder.com/graphql/connection-key',
-        {
-          headers: { 'X-Qminder-REST-API-Key': 'initialkey' },
-          method: 'POST',
-          mode: 'cors',
-        },
-      );
-    });
   });
 
   function useFakeSetInterval() {

--- a/src/lib/services/temporary-api-key/temporary-api-key.service.spec.ts
+++ b/src/lib/services/temporary-api-key/temporary-api-key.service.spec.ts
@@ -10,6 +10,9 @@ describe('Temporary API Key Service', function () {
 
   beforeEach(async () => {
     fetchMock.enableMocks();
+
+    jest.spyOn(global.console, 'info').mockImplementation();
+    jest.spyOn(global.console, 'error').mockImplementation();
   });
 
   afterEach(async () => {
@@ -43,6 +46,7 @@ describe('Temporary API Key Service', function () {
   it('tries again when server responds with 5XX error', async () => {
     fetchMock.mockResponses(
       ['{}', { status: 500, statusText: 'Internal Server Error' }],
+      [JSON.stringify({ key: '12345' }), { status: 200 }],
       [JSON.stringify({ key: '12345' }), { status: 200 }],
     );
     await service.fetchTemporaryApiKey();

--- a/src/lib/services/temporary-api-key/temporary-api-key.service.spec.ts
+++ b/src/lib/services/temporary-api-key/temporary-api-key.service.spec.ts
@@ -51,4 +51,12 @@ describe('Temporary API Key Service', function () {
     );
     await service.fetchTemporaryApiKey();
   });
+
+  it('tries again when response does not contain key', async () => {
+    fetchMock.mockResponses(
+      ['{}', { status: 200 }],
+      [JSON.stringify({ key: '12345' }), { status: 200 }],
+    );
+    await service.fetchTemporaryApiKey();
+  });
 });

--- a/src/lib/services/temporary-api-key/temporary-api-key.service.spec.ts
+++ b/src/lib/services/temporary-api-key/temporary-api-key.service.spec.ts
@@ -1,0 +1,50 @@
+import { TemporaryApiKeyService } from './temporary-api-key.service';
+import fetchMock from 'jest-fetch-mock';
+
+jest.mock('../../util/sleep-ms/sleep-ms', () => ({
+  sleepMs: () => new Promise((resolve) => setTimeout(resolve, 4)),
+}));
+
+describe('Temporary API Key Service', function () {
+  const service = new TemporaryApiKeyService('api.qminder.com', 'initialkey');
+
+  beforeEach(async () => {
+    fetchMock.enableMocks();
+  });
+
+  afterEach(async () => {
+    fetchMock.mockRestore();
+  });
+
+  it('fetches temporary API key', () => {
+    service.fetchTemporaryApiKey();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.qminder.com/graphql/connection-key',
+      {
+        headers: { 'X-Qminder-REST-API-Key': 'initialkey' },
+        method: 'POST',
+        mode: 'cors',
+      },
+    );
+  });
+
+  it('does not try again when server responds with 403', async () => {
+    fetchMock.mockResponseOnce('{}', {
+      status: 403,
+      statusText: 'I Dont know you!',
+    });
+    await expect(
+      async () => await service.fetchTemporaryApiKey(),
+    ).rejects.toThrow();
+  });
+
+  it('tries again when server responds with 5XX error', async () => {
+    fetchMock.mockResponses(
+      ['{}', { status: 500, statusText: 'Internal Server Error' }],
+      [JSON.stringify({ key: '12345' }), { status: 200 }],
+    );
+    await service.fetchTemporaryApiKey();
+  });
+});

--- a/src/lib/services/temporary-api-key/temporary-api-key.service.ts
+++ b/src/lib/services/temporary-api-key/temporary-api-key.service.ts
@@ -49,7 +49,14 @@ export class TemporaryApiKeyService {
 
     try {
       const responseJson = await response.json();
-      return responseJson.key;
+      const key = responseJson.key;
+      if (typeof key === 'undefined') {
+        throw new Error(
+          `Response does not contain key. Response: ${JSON.stringify(
+            responseJson,
+          )}`,
+        );
+      }
     } catch (e) {
       console.error(
         '[Qminder API]: Failed to parse the temporary API key response',

--- a/src/lib/services/temporary-api-key/temporary-api-key.service.ts
+++ b/src/lib/services/temporary-api-key/temporary-api-key.service.ts
@@ -1,0 +1,84 @@
+import { RequestInit } from '../../model/fetch';
+import { sleepMs } from '../../util/sleep-ms/sleep-ms';
+
+export class TemporaryApiKeyService {
+  private readonly apiServer: string;
+  private readonly permanentApiKey: string;
+
+  constructor(apiServer: string, permanentApiKey: string) {
+    this.apiServer = apiServer;
+    this.permanentApiKey = permanentApiKey;
+  }
+
+  async fetchTemporaryApiKey(retryCount = 0): Promise<string> {
+    const url = 'graphql/connection-key';
+    const body: RequestInit = {
+      method: 'POST',
+      mode: 'cors',
+      headers: {
+        'X-Qminder-REST-API-Key': this.permanentApiKey,
+      },
+    };
+
+    let response: Response;
+
+    try {
+      response = await fetch(`https://${this.apiServer}/${url}`, body);
+    } catch (e) {
+      if (this.isBrowserOnline()) {
+        console.warn('[Qminder API]: Failed to fetch temporary API key');
+      } else {
+        console.info(
+          '[Qminder API]: Failed to fetch temporary API key. The browser is offline.',
+        );
+      }
+      return this.retry(retryCount + 1);
+    }
+
+    if (response.status === 403) {
+      throw new Error(
+        'Provided API key is invalid. Unable to fetch temporary key',
+      );
+    }
+    if (response.status >= 500) {
+      console.error(
+        `Failed to fetch API key from the server. Status: ${response.status}`,
+      );
+      return this.retry(retryCount + 1);
+    }
+
+    try {
+      const responseJson = await response.json();
+      return responseJson.key;
+    } catch (e) {
+      console.error(
+        '[Qminder API]: Failed to parse the temporary API key response',
+        e,
+      );
+      return this.retry(retryCount + 1);
+    }
+  }
+
+  private async retry(retryCount = 0): Promise<string> {
+    const timeOutMs = Math.min(60000, Math.max(5000, 2 ** retryCount * 1000));
+    const timeOutSec = timeOutMs / 1000;
+    console.info(
+      `[Qminder API]: Retrying to fetch API key in ${
+        timeOutSec / 1000
+      } seconds`,
+    );
+    await sleepMs(timeOutMs);
+    return this.fetchTemporaryApiKey(retryCount + 1);
+  }
+
+  /**
+   * Returns the online status of the browser.
+   * In the non-browser environment (NodeJS) this always returns true.
+   */
+  private isBrowserOnline(): boolean {
+    if (typeof navigator === 'undefined') {
+      return true;
+    }
+    return navigator.onLine;
+  }
+}


### PR DESCRIPTION
Fixes:
* Does not retry when server responds with status `403`
* Retries when status is `500` or higher
* Tests if the response contains `key`

Refactored whole temporary API key fetching to a separate service

## Related issues



## Checklist

- [ ] Code is covered with tests.
