### PR TITLE
feat: validating if ticket creation has expected response body

### DIFF
--- a/packages/javascript-api/package.json
+++ b/packages/javascript-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "13.4.2",
+  "version": "14.0.0",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system.",
   "scripts": {
     "test": "jest",

--- a/packages/javascript-api/src/lib/model/errors/response-validation-error.ts
+++ b/packages/javascript-api/src/lib/model/errors/response-validation-error.ts
@@ -1,0 +1,5 @@
+export class ResponseValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/packages/javascript-api/src/lib/model/ticket/ticket-created-response.ts
+++ b/packages/javascript-api/src/lib/model/ticket/ticket-created-response.ts
@@ -1,5 +1,3 @@
-import { ID } from '../../util/id-or-object';
-
 export interface TicketCreatedResponse {
-  id: ID;
+  id: string;
 }

--- a/packages/javascript-api/src/lib/services/ticket/ticket.service.spec.ts
+++ b/packages/javascript-api/src/lib/services/ticket/ticket.service.spec.ts
@@ -4,6 +4,7 @@ import { TicketCreatedResponse } from '../../model/ticket/ticket-created-respons
 import { TicketCreationRequest } from '../../model/ticket/ticket-creation-request';
 import { Qminder } from '../../qminder';
 import { TicketService } from './ticket.service';
+import { ResponseValidationError } from '../../model/errors/response-validation-error';
 
 describe('Ticket service', function () {
   const JON_SNOW = {
@@ -807,7 +808,7 @@ describe('Ticket service', function () {
       };
       await expect(async () => {
         await TicketService.create(request);
-      }).rejects.toThrow(new Error('Failed to create a ticket'));
+      }).rejects.toThrow(new ResponseValidationError('Response does not contain "id"'));
     });
   });
 

--- a/packages/javascript-api/src/lib/services/ticket/ticket.service.spec.ts
+++ b/packages/javascript-api/src/lib/services/ticket/ticket.service.spec.ts
@@ -808,7 +808,9 @@ describe('Ticket service', function () {
       };
       await expect(async () => {
         await TicketService.create(request);
-      }).rejects.toThrow(new ResponseValidationError('Response does not contain "id"'));
+      }).rejects.toThrow(
+        new ResponseValidationError('Response does not contain "id"'),
+      );
     });
   });
 

--- a/packages/javascript-api/src/lib/services/ticket/ticket.service.spec.ts
+++ b/packages/javascript-api/src/lib/services/ticket/ticket.service.spec.ts
@@ -796,6 +796,19 @@ describe('Ticket service', function () {
       });
       expect(res).toEqual(SUCCESSFUL_RESPONSE);
     });
+
+    it('should throw when response does not contain ID', async () => {
+      requestStub.mockResolvedValue({});
+      const request: TicketCreationRequest = {
+        lineId: '41299290',
+        firstName: 'James',
+        lastName: 'Baxter',
+        email: 'foo@bar.com',
+      };
+      await expect(async () => {
+        await TicketService.create(request);
+      }).rejects.toThrow(new Error('Failed to create a ticket'));
+    });
   });
 
   describe('details()', function () {

--- a/packages/javascript-api/src/lib/services/ticket/ticket.ts
+++ b/packages/javascript-api/src/lib/services/ticket/ticket.ts
@@ -319,18 +319,23 @@ export function count(search: TicketCountCriteria): Promise<number> {
   );
 }
 
-export function create(
+export async function create(
   request: TicketCreationRequest,
 ): Promise<TicketCreatedResponse> {
   const body = JSON.stringify(request);
 
-  return ApiBase.request('tickets', {
+  const result: TicketCreatedResponse = await ApiBase.request('tickets', {
     method: 'POST',
     body,
     headers: {
       'X-Qminder-API-Version': '2020-09-01',
     },
   });
+  if (!result.id) {
+    throw new Error('Failed to create a ticket');
+  }
+
+  return result;
 }
 
 export function details(ticket: IdOrObject<Ticket>): Promise<Ticket> {

--- a/packages/javascript-api/src/lib/services/ticket/ticket.ts
+++ b/packages/javascript-api/src/lib/services/ticket/ticket.ts
@@ -10,6 +10,7 @@ import {
   extractIdToNumber,
 } from '../../util/id-or-object.js';
 import { ApiBase } from '../api-base/api-base.js';
+import { ResponseValidationError } from '../../model/errors/response-validation-error.js';
 
 /**
  * Represents a collection of search criteria for TicketService.count().
@@ -332,7 +333,7 @@ export async function create(
     },
   });
   if (!result.id) {
-    throw new Error('Failed to create a ticket');
+    throw new ResponseValidationError('Response does not contain "id"');
   }
 
   return result;

--- a/packages/javascript-api/src/public-api/model.ts
+++ b/packages/javascript-api/src/public-api/model.ts
@@ -17,6 +17,7 @@ export { User } from '../lib/model/user.js';
 export { Webhook } from '../lib/model/webhook.js';
 export { SimpleError } from '../lib/model/errors/simple-error.js';
 export { ComplexError } from '../lib/model/errors/complex-error.js';
+export { ResponseValidationError } from '../lib/model/errors/response-validation-error.js';
 export { UnknownError } from '../lib/model/errors/unknown-error.js';
 export { TicketCreationRequest } from '../lib/model/ticket/ticket-creation-request.js';
 export { TicketCreatedResponse } from '../lib/model/ticket/ticket-created-response.js';


### PR DESCRIPTION
* Testing if ticket creation response contains `id`
* Refactored `id` to be always a `string`
* Introduced new typed error `ResponseValidationError`
* Bumped version to `14.0.0` because of the changed return type