### PR TITLE
feat: extracting "errors" from error object

### DIFF
--- a/packages/javascript-api/src/lib/services/api-base/api-base.ts
+++ b/packages/javascript-api/src/lib/services/api-base/api-base.ts
@@ -174,6 +174,9 @@ export class ApiBase {
     if (Object.prototype.hasOwnProperty.call(response, 'error')) {
       return new ComplexError(response.error);
     }
+    if (Object.prototype.hasOwnProperty.call(response, 'errors')) {
+      return new ComplexError(response.errors);
+    }
 
     return new UnknownError();
   }


### PR DESCRIPTION
Sometimes we provide errors in `errors` key