### PR TITLE
feat(`graphql`): remember connection status without subscribers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ build
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
+nohup.out


### PR DESCRIPTION
Remember connection status without subscribers.

Includes:
- Add `nohup.out` (generated by `qminder bind-javascript-api`) to `.gitignore`.

## Related issues

Necessary for [GraphQL is disconnected when creating a new account](https://github.com/Qminder/server/issues/26195).