### PR TITLE
chore(deps): remove unused es6-promise dependency

### DIFF
--- a/packages/javascript-api/package.json
+++ b/packages/javascript-api/package.json
@@ -41,7 +41,6 @@
   "repository": "Qminder/javascript-api",
   "dependencies": {
     "@types/ws": "^8.0.0",
-    "es6-promise": "^4.1.1",
     "isomorphic-ws": "^5.0.0",
     "ws": "^8.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3973,13 +3973,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es6-promise@npm:^4.1.1":
-  version: 4.2.8
-  resolution: "es6-promise@npm:4.2.8"
-  checksum: 10c0/2373d9c5e9a93bdd9f9ed32ff5cb6dd3dd785368d1c21e9bbbfd07d16345b3774ae260f2bd24c8f836a6903f432b4151e7816a7fa8891ccb4e1a55a028ec42c3
-  languageName: node
-  linkType: hard
-
 "esbuild@npm:~0.23.0":
   version: 0.23.1
   resolution: "esbuild@npm:0.23.1"
@@ -6966,7 +6959,6 @@ __metadata:
     "@types/sinon": "npm:17.0.3"
     "@types/ws": "npm:^8.0.0"
     cross-fetch: "npm:^4.0.0"
-    es6-promise: "npm:^4.1.1"
     graphql: "npm:15.10.1"
     graphql-tag: "npm:2.12.6"
     isomorphic-ws: "npm:^5.0.0"


### PR DESCRIPTION
## Summary
- Remove `es6-promise` from runtime dependencies — it is never imported and Node >= 20 has native `Promise` support
- Reduces unnecessary bundle size for consumers

## Test plan
- [x] `yarn build` succeeds
- [x] All 294 tests pass