### PR TITLE
fix: replace any with proper timer types in GraphqlService

### DIFF
--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -112,8 +112,8 @@ export class GraphqlService {
   private readonly subscriptionConnection$: Observable<ConnectionStatus>;
   private temporaryApiKeyService: TemporaryApiKeyService | undefined;
 
-  private pongTimeout: any;
-  private pingPongInterval: any;
+  private pongTimeout: ReturnType<typeof setTimeout> | undefined;
+  private pingPongInterval: ReturnType<typeof setInterval> | undefined;
   private readonly sendPingWithThisBound = this.sendPing.bind(this);
 
   private readonly handleConnectionDropWithThisBound =


### PR DESCRIPTION
## Summary
- Replace `any` type on `pongTimeout` and `pingPongInterval` with `ReturnType<typeof setTimeout> | undefined` and `ReturnType<typeof setInterval> | undefined`
- Cross-environment idiomatic TypeScript approach (works in both Node.js and browser)
- Type-only change, no runtime behavior affected

## Test plan
- [x] `yarn build` succeeds
- [x] All 294 tests pass