### PR TITLE
Bump version to 17.0.3

### DIFF
--- a/packages/javascript-api/package.json
+++ b/packages/javascript-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "17.0.2",
+  "version": "17.0.3",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system.",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Bumps `qminder-api` from 17.0.2 to 17.0.3 following the merge of #851 (feat(graphql): refactor service).