### PR TITLE
chore(release): implement trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
     types:
       - published
 
+permissions:
+  id-token: write
+  contents: read
+
 defaults:
   run:
     working-directory: ./packages/javascript-api
@@ -13,12 +17,10 @@ jobs:
     name: Publish to NPM Registry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
-          cache: 'yarn'
-          always-auth: true
+          node-version: 24.x
           registry-url: https://registry.npmjs.org
       - name: Install Deps
         run: yarn install --immutable
@@ -26,5 +28,3 @@ jobs:
         run: yarn build
       - name: Publish package to NPM
         run: yarn npm publish
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Implement [trusted publishing](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow).

**NB!** Requires npmjs.com [configuration](https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom).