### PR TITLE
feat(graphql): block retry if connection not established

### DIFF
--- a/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -123,7 +123,7 @@ export class GraphQLSubscriptionsFixture {
   }
 
   async cleanup(): Promise<void> {
-    this.teardownService();
+    this.tearDownService();
     WS.clean();
     await this.server.closed;
   }

--- a/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -128,7 +128,25 @@ export class GraphQLSubscriptionsFixture {
     await this.server.closed;
   }
 
-  private teardownService() {
+  private tearDownService(): void {
+    this.graphqlService['openSocket'] = () => Promise.resolve();
+
+    const socket = this.graphqlService['socket'];
+    if (socket) {
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onerror = null;
+      socket.onclose = null;
+
+      if (typeof socket.close === 'function') {
+        socket.close();
+      }
+
+      this.graphqlService['socket'] = null;
+    }
+
+    this.graphqlService['clearPingMonitoring']();
+  }
     const service = this.graphqlService as any;
 
     service.openSocket = () => Promise.resolve();

--- a/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -147,21 +147,4 @@ export class GraphQLSubscriptionsFixture {
 
     this.graphqlService['clearPingMonitoring']();
   }
-    const service = this.graphqlService as any;
-
-    service.openSocket = () => Promise.resolve();
-
-    if (service.socket) {
-      service.socket.onopen = null;
-      service.socket.onmessage = null;
-      service.socket.onerror = null;
-      service.socket.onclose = null;
-      if (typeof service.socket.close === 'function') {
-        service.socket.close();
-      }
-      service.socket = null;
-    }
-
-    service.clearPingMonitoring();
-  }
 }

--- a/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -122,7 +122,7 @@ export class GraphQLSubscriptionsFixture {
     await this.server.nextMessage;
   }
 
-  async cleanup() {
+  async cleanup(): Promise<void> {
     this.teardownService();
     WS.clean();
     await this.server.closed;

--- a/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__fixtures__/graphql-subscriptions-fixture.ts
@@ -123,7 +123,27 @@ export class GraphQLSubscriptionsFixture {
   }
 
   async cleanup() {
+    this.teardownService();
     WS.clean();
     await this.server.closed;
+  }
+
+  private teardownService() {
+    const service = this.graphqlService as any;
+
+    service.openSocket = () => Promise.resolve();
+
+    if (service.socket) {
+      service.socket.onopen = null;
+      service.socket.onmessage = null;
+      service.socket.onerror = null;
+      service.socket.onclose = null;
+      if (typeof service.socket.close === 'function') {
+        service.socket.close();
+      }
+      service.socket = null;
+    }
+
+    service.clearPingMonitoring();
   }
 }

--- a/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-blocked-websocket.spec.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-blocked-websocket.spec.ts
@@ -1,0 +1,96 @@
+import { WebSocket } from 'mock-socket';
+
+import { GraphQLSubscriptionsFixture } from '../__fixtures__/graphql-subscriptions-fixture';
+import * as backoff from '../../../util/randomized-exponential-backoff/randomized-exponential-backoff';
+
+jest.mock('isomorphic-ws', () => WebSocket);
+jest.mock('../../../util/sleep-ms/sleep-ms', () => ({
+  sleepMs: () => new Promise((resolve) => setTimeout(resolve, 4)),
+}));
+
+// Mirrors the constants in graphql.service.ts (not exported).
+const MAX_FAILED_HANDSHAKES = 5;
+const BLOCKED_RETRY_INTERVAL_MS = 5 * 60 * 1000;
+
+describe('GraphQL blocked-WebSocket back-off', () => {
+  let fixture: GraphQLSubscriptionsFixture;
+
+  beforeEach(() => {
+    fixture = new GraphQLSubscriptionsFixture();
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  it('should back off to a slow interval after repeated handshakes fail before connecting', async () => {
+    const service = fixture.graphqlService as any;
+    const backoffSpy = jest.spyOn(
+      backoff,
+      'calculateRandomizedExponentialBackoffTime',
+    );
+    const infoSpy = jest.spyOn(service.logger, 'info');
+
+    const sub = fixture.triggerSubscription();
+
+    // Each cycle: connect, never ACK, close before the connection is established.
+    for (let i = 0; i < MAX_FAILED_HANDSHAKES; i++) {
+      await fixture.waitForConnection();
+      await fixture.getNextMessage(); // consume connection_init
+      await fixture.closeWithCode(1001);
+      fixture.openServer();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(service.consecutiveFailedHandshakes).toBeGreaterThanOrEqual(
+      MAX_FAILED_HANDSHAKES,
+    );
+    // Fast exponential backoff is used only for the first (MAX - 1) reconnects;
+    // once the cap is hit, the flat slow interval is used instead.
+    expect(backoffSpy).toHaveBeenCalledTimes(MAX_FAILED_HANDSHAKES - 1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      `Reconnect socket in ${BLOCKED_RETRY_INTERVAL_MS}ms`,
+    );
+
+    sub.unsubscribe();
+  });
+
+  it('should not count a close that happens after a successful connection', async () => {
+    const service = fixture.graphqlService as any;
+
+    const sub = fixture.triggerSubscription();
+    await fixture.handleConnectionInit(); // connection_ack -> CONNECTED
+    await fixture.consumeSubscribeMessage();
+
+    expect(service.consecutiveFailedHandshakes).toBe(0);
+
+    // A drop after the connection was established is a normal reconnect.
+    await fixture.closeWithCode(1001);
+    expect(service.consecutiveFailedHandshakes).toBe(0);
+
+    fixture.openServer();
+    await fixture.handleConnectionInit();
+    sub.unsubscribe();
+  });
+
+  it('should reset the counter when the connection is established', async () => {
+    const service = fixture.graphqlService as any;
+
+    const sub = fixture.triggerSubscription();
+
+    for (let i = 0; i < 2; i++) {
+      await fixture.waitForConnection();
+      await fixture.getNextMessage();
+      await fixture.closeWithCode(1001);
+      fixture.openServer();
+    }
+    expect(service.consecutiveFailedHandshakes).toBe(2);
+
+    // A successful connection_ack resets the counter back to fast reconnects.
+    await fixture.handleConnectionInit();
+    await fixture.consumeSubscribeMessage();
+    expect(service.consecutiveFailedHandshakes).toBe(0);
+
+    sub.unsubscribe();
+  });
+});

--- a/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-blocked-websocket.spec.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-blocked-websocket.spec.ts
@@ -36,11 +36,10 @@ describe('GraphQL blocked-WebSocket back-off', () => {
     // Each cycle: connect, never ACK, close before the connection is established.
     for (let i = 0; i < MAX_FAILED_HANDSHAKES; i++) {
       await fixture.waitForConnection();
-      await fixture.getNextMessage(); // consume connection_init
+      await fixture.consumeInitMessage();
       await fixture.closeWithCode(1001);
       fixture.openServer();
     }
-    await new Promise((resolve) => setTimeout(resolve, 20));
 
     expect(service.consecutiveFailedHandshakes).toBeGreaterThanOrEqual(
       MAX_FAILED_HANDSHAKES,

--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -98,6 +98,12 @@ const PING_PONG_INTERVAL_IN_MS = 20_000;
 // https://www.w3.org/TR/websockets/#concept-websocket-close-fail
 const CLIENT_SIDE_CLOSE_EVENT = 1000;
 
+// Once the WebSocket has failed to establish this many times in a row, the reconnect
+// loop backs off to a slow interval instead of minting a new temporary API key on
+// every fast retry. A successful connection resets the counter.
+const MAX_FAILED_HANDSHAKES = 5;
+const BLOCKED_RETRY_INTERVAL_MS = 5 * 60 * 1000;
+
 /**
  * A service that lets the user query Qminder API via GraphQL statements.
  * Queries and subscriptions are supported. There is no support for mutations.
@@ -191,6 +197,10 @@ export class GraphqlService {
     this.handleBrowserOnline.bind(this);
 
   private connectionAttemptsCount = 0;
+
+  // Consecutive WebSocket closes that happened before the connection was ever
+  // established. Reset to 0 on a successful GQL_CONNECTION_ACK.
+  private consecutiveFailedHandshakes = 0;
 
   constructor() {
     this.setServer('api.qminder.com');
@@ -446,14 +456,32 @@ export class GraphqlService {
         reason: event.reason,
       });
 
+      // Capture this before the status is overwritten below: a close while still
+      // CONNECTING means the connection never established.
+      const closedBeforeEstablished =
+        this.connectionStatus === ConnectionStatus.CONNECTING;
+
       this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
       this.socket = null;
       this.clearPingMonitoring();
 
-      if (this.shouldRetry(event)) {
-        const timer = calculateRandomizedExponentialBackoffTime(
-          this.connectionAttemptsCount,
+      if (closedBeforeEstablished) {
+        this.consecutiveFailedHandshakes++;
+        this.logger.error(
+          `Received socket close event before a connection was established! Close code: ${event.code}`,
         );
+      }
+
+      if (this.shouldRetry(event)) {
+        // After repeated failures to establish, back off to a slow interval so we
+        // stop creating a temporary API key on every retry. Recovers on its own:
+        // a successful connection resets consecutiveFailedHandshakes.
+        const timer =
+          this.consecutiveFailedHandshakes >= MAX_FAILED_HANDSHAKES
+            ? BLOCKED_RETRY_INTERVAL_MS
+            : calculateRandomizedExponentialBackoffTime(
+                this.connectionAttemptsCount,
+              );
 
         this.logger.info(`Reconnect socket in ${timer.toFixed(0)}ms`);
 
@@ -465,12 +493,6 @@ export class GraphqlService {
           .catch((error: Error) => {
             this.logger.error('Failed to reconnect socket: ', error);
           });
-      }
-
-      if (this.connectionStatus === ConnectionStatus.CONNECTING) {
-        this.logger.error(
-          `Received socket close event before a connection was established! Close code: ${event.code}`,
-        );
       }
     };
 
@@ -497,6 +519,9 @@ export class GraphqlService {
           this.clearErroredSubscriptionsTimeouts();
           this.retryableErroredSubscriptionsRetryCount = 0;
           this.retryableErroredSubscriptionsAction$.next({ type: 'clear' });
+
+          // Connection established — clear the blocked back-off.
+          this.consecutiveFailedHandshakes = 0;
 
           this.setConnectionStatus(ConnectionStatus.CONNECTED);
           this.logger.info('Connected to websocket');

--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -468,7 +468,8 @@ export class GraphqlService {
       if (closedBeforeEstablished) {
         this.consecutiveFailedHandshakes++;
         this.logger.error(
-          `Received socket close event before a connection was established! Close code: ${event.code}`,
+          `Received socket close event before a connection was established! ` +
+            `Close code: ${event.code} (consecutive failed handshakes: ${this.consecutiveFailedHandshakes})`,
         );
       }
 
@@ -476,12 +477,21 @@ export class GraphqlService {
         // After repeated failures to establish, back off to a slow interval so we
         // stop creating a temporary API key on every retry. Recovers on its own:
         // a successful connection resets consecutiveFailedHandshakes.
-        const timer =
-          this.consecutiveFailedHandshakes >= MAX_FAILED_HANDSHAKES
-            ? BLOCKED_RETRY_INTERVAL_MS
-            : calculateRandomizedExponentialBackoffTime(
-                this.connectionAttemptsCount,
-              );
+        const isBlocked =
+          this.consecutiveFailedHandshakes >= MAX_FAILED_HANDSHAKES;
+
+        if (isBlocked) {
+          this.logger.warn(
+            `Handshake failed ${this.consecutiveFailedHandshakes} times in a row; ` +
+              `backing off to ${BLOCKED_RETRY_INTERVAL_MS}ms to stop creating temporary API keys on every retry.`,
+          );
+        }
+
+        const timer = isBlocked
+          ? BLOCKED_RETRY_INTERVAL_MS
+          : calculateRandomizedExponentialBackoffTime(
+              this.connectionAttemptsCount,
+            );
 
         this.logger.info(`Reconnect socket in ${timer.toFixed(0)}ms`);
 

--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -483,7 +483,7 @@ export class GraphqlService {
         if (isBlocked) {
           this.logger.warn(
             `Handshake failed ${this.consecutiveFailedHandshakes} times in a row; ` +
-              `backing off to ${BLOCKED_RETRY_INTERVAL_MS}ms to stop creating temporary API keys on every retry.`,
+              `slowing down reconnect attempts to ${BLOCKED_RETRY_INTERVAL_MS}ms.`,
           );
         }
 


### PR DESCRIPTION
Back off the GraphQL WebSocket reconnect loop when the socket repeatedly fails to establish, so the SDK stops minting a new temporary API key on every retry.

When a client's firewall blocks `wss://` (but not HTTPS), every reconnect attempt fetched a fresh temporary API key over HTTPS and then failed the WebSocket handshake forever, ~1 key/minute per device.

So now we:
- Count consecutive closes that happen **before** the connection is established (`consecutiveFailedHandshakes`).
- After `MAX_FAILED_HANDSHAKES` (5), the existing reconnect loop backs off to a flat `BLOCKED_RETRY_INTERVAL_MS` (5 min) instead of the fast exponential backoff.
- Reset the counter on `GQL_CONNECTION_ACK`, so it recovers automatically once the connection succeeds.

## How to test

Set up sign-in-wrapper with javascript-api and ipad-sig-in on master first.

Navigate to name.local and set up iPad.

Go to uBlock Origin settings: 
<img width="622" height="501" alt="image" src="https://github.com/user-attachments/assets/d9121a29-e541-47d8-9ab4-39f08ab40fd0" />

Go to `My filters` and disable websockets:

`*$websocket`

<img width="953" height="466" alt="image" src="https://github.com/user-attachments/assets/c1edac88-bcc1-4947-bd14-ce38e868acca" />

You will see how iPad created keys.

Then switch to this PR for javascript-api. The backoff will be applied.
