### PR TITLE
Bump version to 17.0.4

### DIFF
--- a/packages/javascript-api/package.json
+++ b/packages/javascript-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system.",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Bumps `qminder-api` from 17.0.3 to 17.0.4 following the merge of #854 (feat(graphql): block retry if connection not established).