### PR TITLE
fix(release): fix trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Build Library
         run: yarn build
       - name: Publish package to NPM
-        run: yarn npm publish
+        run: npm publish


### PR DESCRIPTION
Fix trusted publishing.

Notes:
- Based on https://github.com/Qminder/ui-components/pull/2448.