### PR TITLE
feat(graphql): backoff for dropped connection after ACK

### DIFF
--- a/packages/javascript-api/package.json
+++ b/packages/javascript-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qminder-api",
-  "version": "17.0.4",
+  "version": "17.0.5",
   "description": "Qminder Javascript API. Makes it easy to leverage Qminder capabilities in your system.",
   "scripts": {
     "test": "jest",

--- a/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-reconnect-resilience.spec.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-reconnect-resilience.spec.ts
@@ -88,6 +88,43 @@ describe('GraphQL reconnect resilience', () => {
     expect(openSocketSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('should tear down the old socket before the backoff sleep so its onclose cannot reconnect', async () => {
+    const service = fixture.graphqlService as any;
+    service.connectionStatus = ConnectionStatus.CONNECTED;
+
+    const closeSpy = jest.fn();
+    const staleSocket = {
+      onclose: () => {},
+      onmessage: () => {},
+      onopen: () => {},
+      onerror: () => {},
+      close: closeSpy,
+    };
+    service.socket = staleSocket;
+
+    const sleepMs = sleep.sleepMs as jest.Mock;
+    sleepMs.mockClear();
+    let resolveSleep: () => void;
+    sleepMs.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSleep = resolve;
+      }),
+    );
+
+    jest.spyOn(service, 'openSocket').mockResolvedValue(undefined);
+
+    const dropPromise = service.handleConnectionDrop();
+
+    // The socket is detached and closed before the backoff window begins, so a
+    // late onclose can't start a second, parallel reconnect.
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(staleSocket.onclose).toBeNull();
+    expect(service.socket).toBeNull();
+
+    resolveSleep();
+    await dropPromise;
+  });
+
   it('should not leak ping intervals when the connection monitor restarts', async () => {
     const setIntervalSpy = jest.spyOn(global, 'setInterval');
     const clearIntervalSpy = jest.spyOn(global, 'clearInterval');

--- a/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-reconnect-resilience.spec.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-reconnect-resilience.spec.ts
@@ -1,11 +1,13 @@
 import { WebSocket } from 'mock-socket';
 
+import { ConnectionStatus } from '../../../model/connection-status';
 import { GraphQLSubscriptionsFixture } from '../__fixtures__/graphql-subscriptions-fixture';
 import * as backoff from '../../../util/randomized-exponential-backoff/randomized-exponential-backoff';
+import * as sleep from '../../../util/sleep-ms/sleep-ms';
 
 jest.mock('isomorphic-ws', () => WebSocket);
 jest.mock('../../../util/sleep-ms/sleep-ms', () => ({
-  sleepMs: () => new Promise((resolve) => setTimeout(resolve, 4)),
+  sleepMs: jest.fn(() => new Promise((resolve) => setTimeout(resolve, 4))),
 }));
 
 describe('GraphQL reconnect resilience', () => {
@@ -39,6 +41,51 @@ describe('GraphQL reconnect resilience', () => {
 
     await fixture.handleConnectionInit();
     sub.unsubscribe();
+  });
+
+  it('should back off using the attempt counter when a connection drops after ACK', async () => {
+    const service = fixture.graphqlService as any;
+    service.connectionStatus = ConnectionStatus.CONNECTED;
+    service.connectionAttemptsCount = 2;
+
+    const openSocketSpy = jest
+      .spyOn(service, 'openSocket')
+      .mockResolvedValue(undefined);
+
+    await service.handleConnectionDrop();
+
+    expect(backoffSpy).toHaveBeenCalledWith(2);
+    expect(service.connectionAttemptsCount).toBe(3);
+    expect(openSocketSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should defer the reconnect until the backoff delay elapses', async () => {
+    const service = fixture.graphqlService as any;
+    service.connectionStatus = ConnectionStatus.CONNECTED;
+
+    const sleepMs = sleep.sleepMs as jest.Mock;
+    sleepMs.mockClear();
+    let resolveSleep: () => void;
+    sleepMs.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSleep = resolve;
+      }),
+    );
+
+    const openSocketSpy = jest
+      .spyOn(service, 'openSocket')
+      .mockResolvedValue(undefined);
+
+    const dropPromise = service.handleConnectionDrop();
+
+    // The backoff is armed, but the reconnect must wait for it to elapse.
+    expect(sleepMs).toHaveBeenCalledTimes(1);
+    expect(openSocketSpy).not.toHaveBeenCalled();
+
+    resolveSleep();
+    await dropPromise;
+
+    expect(openSocketSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should not leak ping intervals when the connection monitor restarts', async () => {

--- a/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-reconnect-resilience.spec.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-reconnect-resilience.spec.ts
@@ -93,7 +93,7 @@ describe('GraphQL reconnect resilience', () => {
     service.connectionStatus = ConnectionStatus.CONNECTED;
 
     const closeSpy = jest.fn();
-    const staleSocket = {
+    const staleSocket: Partial<WebSocket> = {
       onclose: () => {},
       onmessage: () => {},
       onopen: () => {},

--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -774,6 +774,15 @@ export class GraphqlService {
 
     this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
     this.clearPingMonitoring();
+
+    const timer = calculateRandomizedExponentialBackoffTime(
+      this.connectionAttemptsCount,
+    );
+
+    this.connectionAttemptsCount++;
+    this.logger.info(`Reconnect socket after drop in ${timer.toFixed(0)}ms`);
+
+    await sleepMs(timer);
     await this.openSocket();
   }
 

--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -429,14 +429,7 @@ export class GraphqlService {
   }
 
   private createSocketConnection(temporaryApiKey: string): void {
-    if (this.socket) {
-      this.socket.onclose = null;
-      this.socket.onmessage = null;
-      this.socket.onopen = null;
-      this.socket.onerror = null;
-      this.socket.close();
-      this.socket = null;
-    }
+    this.teardownSocket();
 
     this.socket = new WebSocket(this.getServerUrl(temporaryApiKey));
 
@@ -775,6 +768,10 @@ export class GraphqlService {
     this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
     this.clearPingMonitoring();
 
+    // Tear down the old socket before sleeping so its onclose handler can't fire
+    // a second, parallel reconnect during the backoff window.
+    this.teardownSocket();
+
     const timer = calculateRandomizedExponentialBackoffTime(
       this.connectionAttemptsCount,
     );
@@ -784,6 +781,17 @@ export class GraphqlService {
 
     await sleepMs(timer);
     await this.openSocket();
+  }
+
+  private teardownSocket(): void {
+    if (this.socket) {
+      this.socket.onclose = null;
+      this.socket.onmessage = null;
+      this.socket.onopen = null;
+      this.socket.onerror = null;
+      this.socket.close();
+      this.socket = null;
+    }
   }
 
   private clearPingMonitoring(): void {

--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -429,7 +429,7 @@ export class GraphqlService {
   }
 
   private createSocketConnection(temporaryApiKey: string): void {
-    this.teardownSocket();
+    this.tearDownSocket();
 
     this.socket = new WebSocket(this.getServerUrl(temporaryApiKey));
 
@@ -770,7 +770,7 @@ export class GraphqlService {
 
     // Tear down the old socket before sleeping so its onclose handler can't fire
     // a second, parallel reconnect during the backoff window.
-    this.teardownSocket();
+    this.tearDownSocket();
 
     const timer = calculateRandomizedExponentialBackoffTime(
       this.connectionAttemptsCount,
@@ -783,7 +783,7 @@ export class GraphqlService {
     await this.openSocket();
   }
 
-  private teardownSocket(): void {
+  private tearDownSocket(): void {
     if (this.socket) {
       this.socket.onclose = null;
       this.socket.onmessage = null;


### PR DESCRIPTION
Add exponential backoff before reconnecting when an already-established GraphQL WebSocket connection drops, so a connection that keeps dropping right after `connection_ack` doesn't turn into a tight reconnect loop.

Previously `handleConnectionDrop()` (pong timeout, failed send, or resubscription failure) reconnected **immediately** via `openSocket()`. Each reconnect mints a fresh temporary API key, so a server that drops the socket right after ACK produced a fast key-minting loop. The `onclose` handler already backed off for connections that never established; this brings the post-ACK drop path in line.

So now we:
- Back off in `handleConnectionDrop()` using `calculateRandomizedExponentialBackoffTime(connectionAttemptsCount)` before reconnecting, reusing the same counter as `onclose` (reset to 0 on `GQL_PONG`), so a healthy connection that drops starts from the minimum.
- Tear down the old socket (`tearDownSocket()`) **before** the backoff sleep, so its `onclose` can't fire a second, parallel reconnect during the delay. The handlers are nulled before `close()`, so the asynchronous close event has nothing left to trigger.
- Keep the synchronous `DISCONNECTED` emit up front, so the dashboard's connection-loss status is unaffected.
- Extract the duplicated teardown block into a shared `tearDownSocket()` helper used by both `createSocketConnection()` and `handleConnectionDrop()`.

## How to test

- `yarn test` (new tests in `graphql-reconnect-resilience.spec.ts`):
  - drop after ACK backs off using the attempt counter and increments it
  - the reconnect is deferred until the backoff delay elapses (not immediate)
  - the old socket is torn down before the sleep so its `onclose` can't reconnect

Bumps `qminder-api` to 17.0.5.