### PR TITLE
feat(graphql): reply with pong when the server sends a ping

### DIFF
--- a/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__tests__/graphql-subscriptions.spec.ts
@@ -245,6 +245,19 @@ describe('GraphQL subscriptions', () => {
     subscription.unsubscribe();
   });
 
+  it('replies with a pong when the server sends a ping', async () => {
+    const subscription = fixture.triggerSubscription();
+
+    await fixture.handleConnectionInit();
+    await fixture.consumeSubscribeMessage();
+
+    fixture.sendMessageToClient({ type: 'ping' });
+
+    expect(await fixture.getNextMessage()).toEqual({ type: 'pong' });
+
+    subscription.unsubscribe();
+  });
+
   it('when the server sends an error, it will reconnect and subscribe again', async () => {
     const subscription = fixture.triggerSubscription();
     useFakeSetInterval();

--- a/packages/javascript-api/src/lib/services/graphql/__tests__/subscription-protocol.spec.ts
+++ b/packages/javascript-api/src/lib/services/graphql/__tests__/subscription-protocol.spec.ts
@@ -32,6 +32,10 @@ describe('LegacySubscriptionProtocol', () => {
     it('serializes ping without id and payload', () => {
       expect(JSON.parse(protocol.serializePing())).toEqual({ type: 'ping' });
     });
+
+    it('serializes pong without id and payload', () => {
+      expect(JSON.parse(protocol.serializePong())).toEqual({ type: 'pong' });
+    });
   });
 
   describe('incoming frames', () => {
@@ -45,6 +49,12 @@ describe('LegacySubscriptionProtocol', () => {
       expect(
         protocol.parseIncomingMessage('{"type":"connection_ack"}'),
       ).toEqual({ type: 'connection-ack' });
+    });
+
+    it('parses a server-sent ping', () => {
+      expect(protocol.parseIncomingMessage('{"type":"ping"}')).toEqual({
+        type: 'ping',
+      });
     });
 
     it('parses pong', () => {

--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -543,8 +543,6 @@ export class GraphqlService {
         }
 
         case 'ping':
-          // The protocol requires the receiving party to answer a ping as soon
-          // as possible. Only the newer endpoint pings us; the legacy one never does.
           this.sendRawMessage(this.protocol.serializePong());
           break;
 

--- a/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
+++ b/packages/javascript-api/src/lib/services/graphql/graphql.service.ts
@@ -542,6 +542,12 @@ export class GraphqlService {
           break;
         }
 
+        case 'ping':
+          // The protocol requires the receiving party to answer a ping as soon
+          // as possible. Only the newer endpoint pings us; the legacy one never does.
+          this.sendRawMessage(this.protocol.serializePong());
+          break;
+
         case 'pong':
           clearTimeout(this.pongTimeout);
           this.connectionAttemptsCount = 0;

--- a/packages/javascript-api/src/lib/services/graphql/subscription-protocol.ts
+++ b/packages/javascript-api/src/lib/services/graphql/subscription-protocol.ts
@@ -17,6 +17,7 @@ export interface QminderGraphQLError {
 export type IncomingSubscriptionMessage =
   | { readonly type: 'connection-ack' }
   | { readonly type: 'keep-alive' }
+  | { readonly type: 'ping' }
   | { readonly type: 'pong' }
   | {
       readonly type: 'data';
@@ -45,6 +46,11 @@ export interface SubscriptionProtocol {
   serializeSubscribe(id: string, query: string): string;
   serializeUnsubscribe(id: string): string;
   serializePing(): string;
+  /**
+   * A `pong` answering a `ping` from the server. The `graphql-transport-ws`
+   * protocol requires the receiving party to answer a ping as soon as possible.
+   */
+  serializePong(): string;
   parseIncomingMessage(data: string): IncomingSubscriptionMessage;
 }
 
@@ -106,6 +112,10 @@ export class LegacySubscriptionProtocol implements SubscriptionProtocol {
     return JSON.stringify({ type: LegacyMessageType.GQL_PING });
   }
 
+  serializePong(): string {
+    return JSON.stringify({ type: LegacyMessageType.GQL_PONG });
+  }
+
   parseIncomingMessage(data: string): IncomingSubscriptionMessage {
     const message: LegacyMessage = JSON.parse(data);
 
@@ -115,6 +125,9 @@ export class LegacySubscriptionProtocol implements SubscriptionProtocol {
 
       case LegacyMessageType.GQL_CONNECTION_ACK:
         return { type: 'connection-ack' };
+
+      case LegacyMessageType.GQL_PING:
+        return { type: 'ping' };
 
       case LegacyMessageType.GQL_PONG:
         return { type: 'pong' };

--- a/packages/javascript-api/src/lib/services/graphql/subscription-protocol.ts
+++ b/packages/javascript-api/src/lib/services/graphql/subscription-protocol.ts
@@ -46,10 +46,6 @@ export interface SubscriptionProtocol {
   serializeSubscribe(id: string, query: string): string;
   serializeUnsubscribe(id: string): string;
   serializePing(): string;
-  /**
-   * A `pong` answering a `ping` from the server. The `graphql-transport-ws`
-   * protocol requires the receiving party to answer a ping as soon as possible.
-   */
   serializePong(): string;
   parseIncomingMessage(data: string): IncomingSubscriptionMessage;
 }


### PR DESCRIPTION
Answer a server-initiated `ping` with a `pong`, as the `graphql-transport-ws` protocol requires, in preparation for the `/graphql/subscription-v2` migration.

## Why

[PROTOCOL.md](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) defines `Ping`/`Pong` as **bidirectional**:

> A `Pong` must be sent in response from the receiving party as soon as possible.

The client only ever *sent* pings and *received* pongs. A server-initiated `ping` has no `id`, so it fell through `parseIncomingMessage`'s default to `unrecognized`, found no subscriber, and was silently dropped.